### PR TITLE
Fix Scaleway Container Registry authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: deploy
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Associate deploy job with 'deploy' environment to fix Scaleway Container Registry login issue
- Resolves "Password required" error in GitHub Actions deployment workflow

## Test plan
- [ ] Verify deployment workflow runs successfully with environment-specific SCW_SECRET_KEY
- [ ] Confirm container image builds and pushes to Scaleway registry