### PR TITLE
fix(test): mark health metrics test as network-dependent

### DIFF
--- a/tests/mcp_resource_tests.rs
+++ b/tests/mcp_resource_tests.rs
@@ -125,6 +125,7 @@ async fn test_stations_complete_endpoint_returns_combined_data() {
 
 /// Test that the health endpoint returns real system metrics
 #[tokio::test]
+#[ignore = "requires live network access to Velib API"]
 async fn test_health_endpoint_returns_real_metrics() {
     let router = McpServer::new().router();
 


### PR DESCRIPTION
## Summary
- Marks `test_health_endpoint_returns_real_metrics` with `#[ignore]`
- The test asserts `data_sources["real_time"]["last_update"].is_string()` but this field is null when no Velib API fetch has succeeded
- Nix's hermetic sandbox (used in both `nix build .#container` and CI) has no network, so the assertion fails