### PR TITLE
fix(deploy): use Docker instead of podman in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,26 +57,27 @@ jobs:
         run: |
           nix build .#container --print-build-logs --accept-flake-config
 
-      - name: Load container into podman
+      - name: Load container into Docker
         run: |
           CONTAINER_PATH=$(nix path-info .#container)
-          skopeo copy "docker-archive:$CONTAINER_PATH" "containers-storage:$CONTAINER_NAME:latest"
+          docker load -i "$CONTAINER_PATH"
+          docker tag velib-mcp:latest $CONTAINER_NAME:latest
 
       - name: Run container checks
         run: |
           chmod +x ./container_checks.sh
-          ./container_checks.sh
+          CONTAINER_RUNTIME=docker ./container_checks.sh
 
       - name: Login to Scaleway Container Registry
         env:
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
         run: |
-          echo "$SCW_SECRET_KEY" | podman login $SCALEWAY_REGISTRY -u nologin --password-stdin
+          echo "$SCW_SECRET_KEY" | docker login $SCALEWAY_REGISTRY -u nologin --password-stdin
 
       - name: Tag and push container
         run: |
-          podman tag $CONTAINER_NAME:latest $SCALEWAY_REGISTRY/$CONTAINER_NAME:latest
-          podman push $SCALEWAY_REGISTRY/$CONTAINER_NAME:latest
+          docker tag $CONTAINER_NAME:latest $SCALEWAY_REGISTRY/$CONTAINER_NAME:latest
+          docker push $SCALEWAY_REGISTRY/$CONTAINER_NAME:latest
 
       - name: Deploy to Scaleway
         env:

--- a/container_checks.sh
+++ b/container_checks.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 STATUS=0
 CONTAINER_ID=""
+RUNTIME=${CONTAINER_RUNTIME:-podman}
 
 find_available_port() {
   local port=8080
@@ -23,8 +24,8 @@ find_available_port() {
 cleanup() {
   if [ -n "$CONTAINER_ID" ]; then
     echo "Cleaning up container..."
-    podman stop "$CONTAINER_ID" &> /dev/null || true
-    podman rm "$CONTAINER_ID" &> /dev/null || true
+    $RUNTIME stop "$CONTAINER_ID" &> /dev/null || true
+    $RUNTIME rm "$CONTAINER_ID" &> /dev/null || true
   fi
 }
 
@@ -36,7 +37,7 @@ cd "$SCRIPT_DIR"
 PORT=$(find_available_port)
 echo "Using port $PORT for container checks"
 
-CONTAINER_ID=$(podman run -d -p $PORT:8080 velib-mcp)
+CONTAINER_ID=$($RUNTIME run -d -p $PORT:8080 velib-mcp)
 echo "Container ID: $CONTAINER_ID"
 
 echo "Waiting for HTTP server to be ready..."
@@ -49,9 +50,9 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
     break
   fi
 
-  if ! podman ps --filter "id=$CONTAINER_ID" --format "{{.ID}}" | grep -q "${CONTAINER_ID:0:12}"; then
+  if ! $RUNTIME ps --filter "id=$CONTAINER_ID" --format "{{.ID}}" | grep -q "${CONTAINER_ID:0:12}"; then
     echo "ERROR: Container exited prematurely"
-    podman logs "$CONTAINER_ID"
+    $RUNTIME logs "$CONTAINER_ID"
     STATUS=1
     exit $STATUS
   fi
@@ -62,7 +63,7 @@ done
 
 if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
   echo "ERROR: HTTP server failed to start within ${MAX_RETRIES} seconds"
-  podman logs "$CONTAINER_ID"
+  $RUNTIME logs "$CONTAINER_ID"
   STATUS=1
   exit $STATUS
 fi


### PR DESCRIPTION
## Summary
- GitHub Actions runners block `unshare` (user namespaces) which `containers-storage:` transport requires
- Replace `skopeo copy ... containers-storage:` with `docker load` 
- Replace `podman login/tag/push` with `docker login/tag/push`
- `container_checks.sh` now uses `CONTAINER_RUNTIME` env var (default: podman) so it works both locally (podman) and in CI (docker)