### PR TITLE
test: improve coverage for cache, errors, bounds, and JSON-RPC

### DIFF
--- a/src/data/cache_tests.rs
+++ b/src/data/cache_tests.rs
@@ -1,151 +1,146 @@
-#[cfg(test)]
-mod tests {
-    use crate::data::cache::{CacheEntry, InMemoryCache};
-    use chrono::Duration;
+use super::cache::{CacheEntry, InMemoryCache};
+use chrono::Duration;
 
-    #[test]
-    fn cache_entry_not_expired_within_ttl() {
-        let entry = CacheEntry::new(42, Duration::seconds(60));
-        assert!(!entry.is_expired());
-    }
+#[test]
+fn cache_entry_not_expired_within_ttl() {
+    let entry = CacheEntry::new(42, Duration::seconds(60));
+    assert!(!entry.is_expired());
+}
 
-    #[test]
-    fn cache_entry_expired_with_negative_ttl() {
-        // A TTL in the past should be immediately expired
-        let entry = CacheEntry::new(42, Duration::seconds(-1));
-        assert!(entry.is_expired());
-    }
+#[test]
+fn cache_entry_expired_with_negative_ttl() {
+    // A TTL in the past should be immediately expired
+    let entry = CacheEntry::new(42, Duration::seconds(-1));
+    assert!(entry.is_expired());
+}
 
-    #[test]
-    fn cache_entry_expired_with_zero_ttl() {
-        // Zero TTL means expires at the instant of creation;
-        // by the time we check, it should be expired (or borderline).
-        let entry = CacheEntry::new("hello", Duration::seconds(0));
-        // Allow for the tiny elapsed time
-        // This is technically racy but a zero-TTL entry is definitionally stale.
-        assert!(entry.is_expired());
-    }
+#[test]
+fn cache_entry_expired_with_zero_ttl() {
+    // Zero TTL means expires at the instant of creation;
+    // by the time we check, it should be expired (or borderline).
+    let entry = CacheEntry::new("hello", Duration::seconds(0));
+    assert!(entry.is_expired());
+}
 
-    #[tokio::test]
-    async fn insert_then_get_returns_value() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
-        cache.insert("key".into(), 100).await;
+#[tokio::test]
+async fn insert_then_get_returns_value() {
+    let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+    cache.insert("key".into(), 100).await;
 
-        let val = cache.get(&"key".into()).await;
-        assert_eq!(val, Some(100));
-    }
+    let val = cache.get(&"key".into()).await;
+    assert_eq!(val, Some(100));
+}
 
-    #[tokio::test]
-    async fn get_missing_key_returns_none() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
-        assert_eq!(cache.get(&"missing".into()).await, None);
-    }
+#[tokio::test]
+async fn get_missing_key_returns_none() {
+    let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+    assert_eq!(cache.get(&"missing".into()).await, None);
+}
 
-    #[tokio::test]
-    async fn expired_entry_returns_none() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(-1));
-        cache.insert("key".into(), 99).await;
+#[tokio::test]
+async fn expired_entry_returns_none() {
+    let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(-1));
+    cache.insert("key".into(), 99).await;
 
-        // Entry was inserted with a TTL that has already passed
-        assert_eq!(cache.get(&"key".into()).await, None);
-    }
+    // Entry was inserted with a TTL that has already passed
+    assert_eq!(cache.get(&"key".into()).await, None);
+}
 
-    #[tokio::test]
-    async fn insert_with_custom_ttl_overrides_default() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
-        // Insert with a TTL that is already expired
-        cache
-            .insert_with_ttl("short".into(), 1, Duration::seconds(-1))
-            .await;
-        // Insert with a long TTL
-        cache
-            .insert_with_ttl("long".into(), 2, Duration::seconds(300))
-            .await;
+#[tokio::test]
+async fn insert_with_custom_ttl_overrides_default() {
+    let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+    // Insert with a TTL that is already expired
+    cache
+        .insert_with_ttl("short".into(), 1, Duration::seconds(-1))
+        .await;
+    // Insert with a long TTL
+    cache
+        .insert_with_ttl("long".into(), 2, Duration::seconds(300))
+        .await;
 
-        assert_eq!(cache.get(&"short".into()).await, None);
-        assert_eq!(cache.get(&"long".into()).await, Some(2));
-    }
+    assert_eq!(cache.get(&"short".into()).await, None);
+    assert_eq!(cache.get(&"long".into()).await, Some(2));
+}
 
-    #[tokio::test]
-    async fn remove_returns_value_and_evicts() {
-        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::seconds(60));
-        cache.insert("k".into(), "v".into()).await;
+#[tokio::test]
+async fn remove_returns_value_and_evicts() {
+    let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::seconds(60));
+    cache.insert("k".into(), "v".into()).await;
 
-        let removed = cache.remove(&"k".into()).await;
-        assert_eq!(removed, Some("v".into()));
+    let removed = cache.remove(&"k".into()).await;
+    assert_eq!(removed, Some("v".into()));
 
-        // Subsequent get should return None
-        assert_eq!(cache.get(&"k".into()).await, None);
-    }
+    // Subsequent get should return None
+    assert_eq!(cache.get(&"k".into()).await, None);
+}
 
-    #[tokio::test]
-    async fn remove_missing_key_returns_none() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
-        assert_eq!(cache.remove(&"nope".into()).await, None);
-    }
+#[tokio::test]
+async fn remove_missing_key_returns_none() {
+    let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+    assert_eq!(cache.remove(&"nope".into()).await, None);
+}
 
-    #[tokio::test]
-    async fn size_tracks_insertions() {
-        let cache: InMemoryCache<u32, u32> = InMemoryCache::new(Duration::seconds(60));
-        assert_eq!(cache.size().await, 0);
+#[tokio::test]
+async fn size_tracks_insertions() {
+    let cache: InMemoryCache<u32, u32> = InMemoryCache::new(Duration::seconds(60));
+    assert_eq!(cache.size().await, 0);
 
-        cache.insert(1, 10).await;
-        cache.insert(2, 20).await;
-        assert_eq!(cache.size().await, 2);
+    cache.insert(1, 10).await;
+    cache.insert(2, 20).await;
+    assert_eq!(cache.size().await, 2);
 
-        // Overwriting a key should not increase the count
-        cache.insert(1, 11).await;
-        assert_eq!(cache.size().await, 2);
-    }
+    // Overwriting a key should not increase the count
+    cache.insert(1, 11).await;
+    assert_eq!(cache.size().await, 2);
+}
 
-    #[tokio::test]
-    async fn clear_empties_cache() {
-        let cache: InMemoryCache<u32, u32> = InMemoryCache::new(Duration::seconds(60));
-        cache.insert(1, 10).await;
-        cache.insert(2, 20).await;
-        assert_eq!(cache.size().await, 2);
+#[tokio::test]
+async fn clear_empties_cache() {
+    let cache: InMemoryCache<u32, u32> = InMemoryCache::new(Duration::seconds(60));
+    cache.insert(1, 10).await;
+    cache.insert(2, 20).await;
+    assert_eq!(cache.size().await, 2);
 
-        cache.clear().await;
-        assert_eq!(cache.size().await, 0);
-        assert_eq!(cache.get(&1).await, None);
-    }
+    cache.clear().await;
+    assert_eq!(cache.size().await, 0);
+    assert_eq!(cache.get(&1).await, None);
+}
 
-    #[tokio::test]
-    async fn cleanup_expired_removes_only_stale_entries() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+#[tokio::test]
+async fn cleanup_expired_removes_only_stale_entries() {
+    let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
 
-        // Insert a fresh entry with long TTL
-        cache
-            .insert_with_ttl("fresh".into(), 1, Duration::seconds(300))
-            .await;
-        // Insert a stale entry with negative TTL
-        cache
-            .insert_with_ttl("stale".into(), 2, Duration::seconds(-1))
-            .await;
+    // Insert a fresh entry with long TTL
+    cache
+        .insert_with_ttl("fresh".into(), 1, Duration::seconds(300))
+        .await;
+    // Insert a stale entry with negative TTL
+    cache
+        .insert_with_ttl("stale".into(), 2, Duration::seconds(-1))
+        .await;
 
-        assert_eq!(cache.size().await, 2);
+    assert_eq!(cache.size().await, 2);
 
-        cache.cleanup_expired().await;
+    cache.cleanup_expired().await;
 
-        assert_eq!(cache.size().await, 1);
-        assert_eq!(cache.get(&"fresh".into()).await, Some(1));
-        assert_eq!(cache.get(&"stale".into()).await, None);
-    }
+    assert_eq!(cache.size().await, 1);
+    assert_eq!(cache.get(&"fresh".into()).await, Some(1));
+    assert_eq!(cache.get(&"stale".into()).await, None);
+}
 
-    #[tokio::test]
-    async fn overwrite_refreshes_ttl() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+#[tokio::test]
+async fn overwrite_refreshes_ttl() {
+    let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
 
-        // First insert with short (expired) TTL
-        cache
-            .insert_with_ttl("k".into(), 1, Duration::seconds(-1))
-            .await;
-        assert_eq!(cache.get(&"k".into()).await, None);
+    // First insert with short (expired) TTL
+    cache
+        .insert_with_ttl("k".into(), 1, Duration::seconds(-1))
+        .await;
+    assert_eq!(cache.get(&"k".into()).await, None);
 
-        // Overwrite with long TTL
-        cache
-            .insert_with_ttl("k".into(), 2, Duration::seconds(300))
-            .await;
-        assert_eq!(cache.get(&"k".into()).await, Some(2));
-    }
+    // Overwrite with long TTL
+    cache
+        .insert_with_ttl("k".into(), 2, Duration::seconds(300))
+        .await;
+    assert_eq!(cache.get(&"k".into()).await, Some(2));
 }

--- a/src/data/cache_tests.rs
+++ b/src/data/cache_tests.rs
@@ -1,0 +1,151 @@
+#[cfg(test)]
+mod tests {
+    use crate::data::cache::{CacheEntry, InMemoryCache};
+    use chrono::Duration;
+
+    #[test]
+    fn cache_entry_not_expired_within_ttl() {
+        let entry = CacheEntry::new(42, Duration::seconds(60));
+        assert!(!entry.is_expired());
+    }
+
+    #[test]
+    fn cache_entry_expired_with_negative_ttl() {
+        // A TTL in the past should be immediately expired
+        let entry = CacheEntry::new(42, Duration::seconds(-1));
+        assert!(entry.is_expired());
+    }
+
+    #[test]
+    fn cache_entry_expired_with_zero_ttl() {
+        // Zero TTL means expires at the instant of creation;
+        // by the time we check, it should be expired (or borderline).
+        let entry = CacheEntry::new("hello", Duration::seconds(0));
+        // Allow for the tiny elapsed time
+        // This is technically racy but a zero-TTL entry is definitionally stale.
+        assert!(entry.is_expired());
+    }
+
+    #[tokio::test]
+    async fn insert_then_get_returns_value() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert("key".into(), 100).await;
+
+        let val = cache.get(&"key".into()).await;
+        assert_eq!(val, Some(100));
+    }
+
+    #[tokio::test]
+    async fn get_missing_key_returns_none() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        assert_eq!(cache.get(&"missing".into()).await, None);
+    }
+
+    #[tokio::test]
+    async fn expired_entry_returns_none() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(-1));
+        cache.insert("key".into(), 99).await;
+
+        // Entry was inserted with a TTL that has already passed
+        assert_eq!(cache.get(&"key".into()).await, None);
+    }
+
+    #[tokio::test]
+    async fn insert_with_custom_ttl_overrides_default() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        // Insert with a TTL that is already expired
+        cache
+            .insert_with_ttl("short".into(), 1, Duration::seconds(-1))
+            .await;
+        // Insert with a long TTL
+        cache
+            .insert_with_ttl("long".into(), 2, Duration::seconds(300))
+            .await;
+
+        assert_eq!(cache.get(&"short".into()).await, None);
+        assert_eq!(cache.get(&"long".into()).await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn remove_returns_value_and_evicts() {
+        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert("k".into(), "v".into()).await;
+
+        let removed = cache.remove(&"k".into()).await;
+        assert_eq!(removed, Some("v".into()));
+
+        // Subsequent get should return None
+        assert_eq!(cache.get(&"k".into()).await, None);
+    }
+
+    #[tokio::test]
+    async fn remove_missing_key_returns_none() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        assert_eq!(cache.remove(&"nope".into()).await, None);
+    }
+
+    #[tokio::test]
+    async fn size_tracks_insertions() {
+        let cache: InMemoryCache<u32, u32> = InMemoryCache::new(Duration::seconds(60));
+        assert_eq!(cache.size().await, 0);
+
+        cache.insert(1, 10).await;
+        cache.insert(2, 20).await;
+        assert_eq!(cache.size().await, 2);
+
+        // Overwriting a key should not increase the count
+        cache.insert(1, 11).await;
+        assert_eq!(cache.size().await, 2);
+    }
+
+    #[tokio::test]
+    async fn clear_empties_cache() {
+        let cache: InMemoryCache<u32, u32> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert(1, 10).await;
+        cache.insert(2, 20).await;
+        assert_eq!(cache.size().await, 2);
+
+        cache.clear().await;
+        assert_eq!(cache.size().await, 0);
+        assert_eq!(cache.get(&1).await, None);
+    }
+
+    #[tokio::test]
+    async fn cleanup_expired_removes_only_stale_entries() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+
+        // Insert a fresh entry with long TTL
+        cache
+            .insert_with_ttl("fresh".into(), 1, Duration::seconds(300))
+            .await;
+        // Insert a stale entry with negative TTL
+        cache
+            .insert_with_ttl("stale".into(), 2, Duration::seconds(-1))
+            .await;
+
+        assert_eq!(cache.size().await, 2);
+
+        cache.cleanup_expired().await;
+
+        assert_eq!(cache.size().await, 1);
+        assert_eq!(cache.get(&"fresh".into()).await, Some(1));
+        assert_eq!(cache.get(&"stale".into()).await, None);
+    }
+
+    #[tokio::test]
+    async fn overwrite_refreshes_ttl() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+
+        // First insert with short (expired) TTL
+        cache
+            .insert_with_ttl("k".into(), 1, Duration::seconds(-1))
+            .await;
+        assert_eq!(cache.get(&"k".into()).await, None);
+
+        // Overwrite with long TTL
+        cache
+            .insert_with_ttl("k".into(), 2, Duration::seconds(300))
+            .await;
+        assert_eq!(cache.get(&"k".into()).await, Some(2));
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,5 +2,8 @@ pub mod cache;
 pub mod client;
 pub mod retry;
 
+#[cfg(test)]
+mod cache_tests;
+
 pub use client::VelibDataClient;
 pub use retry::{RetryConfig, RetryPolicy, RetryStrategy, RetryableHttpClient};

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,0 +1,137 @@
+//! Tests for error module: MCP error code mapping and error type strings.
+
+use velib_mcp::Error;
+
+#[test]
+fn mcp_error_codes_follow_jsonrpc_spec() {
+    // -32602: Invalid params
+    let invalid_coords = Error::InvalidCoordinates {
+        latitude: 999.0,
+        longitude: 999.0,
+    };
+    assert_eq!(invalid_coords.mcp_error_code(), -32602);
+
+    let outside = Error::OutsideServiceArea { distance_km: 100.0 };
+    assert_eq!(outside.mcp_error_code(), -32602);
+
+    let radius = Error::SearchRadiusTooLarge {
+        radius: 9999,
+        max: 5000,
+    };
+    assert_eq!(radius.mcp_error_code(), -32602);
+
+    let limit = Error::ResultLimitExceeded { limit: 200, max: 100 };
+    assert_eq!(limit.mcp_error_code(), -32602);
+
+    let validation = Error::Validation("bad input".into());
+    assert_eq!(validation.mcp_error_code(), -32602);
+
+    // -32700: Parse error
+    let json_err = Error::Json(serde_json::from_str::<i32>("not json").unwrap_err());
+    assert_eq!(json_err.mcp_error_code(), -32700);
+
+    // -32600: Invalid request
+    let not_found = Error::StationNotFound {
+        station_code: "XYZ".into(),
+    };
+    assert_eq!(not_found.mcp_error_code(), -32600);
+
+    // -32603: Internal error
+    let mcp = Error::McpProtocol("bad".into());
+    assert_eq!(mcp.mcp_error_code(), -32603);
+
+    let cache = Error::Cache("fail".into());
+    assert_eq!(cache.mcp_error_code(), -32603);
+
+    let internal = Error::Internal(anyhow::anyhow!("boom"));
+    assert_eq!(internal.mcp_error_code(), -32603);
+
+    // -32001: Server error (HTTP / rate limit)
+    let rate = Error::RateLimited {
+        retry_after_seconds: Some(30),
+    };
+    assert_eq!(rate.mcp_error_code(), -32001);
+
+    let rate_none = Error::RateLimited {
+        retry_after_seconds: None,
+    };
+    assert_eq!(rate_none.mcp_error_code(), -32001);
+}
+
+#[test]
+fn error_type_strings_are_unique_and_snake_case() {
+    let errors: Vec<Box<dyn Fn() -> Error>> = vec![
+        Box::new(|| Error::InvalidCoordinates {
+            latitude: 0.0,
+            longitude: 0.0,
+        }),
+        Box::new(|| Error::OutsideServiceArea { distance_km: 1.0 }),
+        Box::new(|| Error::SearchRadiusTooLarge {
+            radius: 1,
+            max: 1,
+        }),
+        Box::new(|| Error::ResultLimitExceeded { limit: 1, max: 1 }),
+        Box::new(|| Error::Validation("x".into())),
+        Box::new(|| Error::StationNotFound {
+            station_code: "x".into(),
+        }),
+        Box::new(|| Error::McpProtocol("x".into())),
+        Box::new(|| Error::Cache("x".into())),
+        Box::new(|| Error::Internal(anyhow::anyhow!("x"))),
+        Box::new(|| Error::RateLimited {
+            retry_after_seconds: None,
+        }),
+    ];
+
+    let mut seen = std::collections::HashSet::new();
+    for make_err in &errors {
+        let err = make_err();
+        let ty = err.error_type();
+
+        // Must be snake_case (lowercase + underscores only)
+        assert!(
+            ty.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+            "error_type '{ty}' is not snake_case"
+        );
+
+        // Must be unique
+        assert!(
+            seen.insert(ty),
+            "duplicate error_type '{ty}'"
+        );
+    }
+}
+
+#[test]
+fn error_display_messages_are_non_empty() {
+    let errors: Vec<Error> = vec![
+        Error::InvalidCoordinates {
+            latitude: 1.0,
+            longitude: 2.0,
+        },
+        Error::OutsideServiceArea { distance_km: 55.0 },
+        Error::SearchRadiusTooLarge {
+            radius: 6000,
+            max: 5000,
+        },
+        Error::ResultLimitExceeded { limit: 200, max: 100 },
+        Error::Validation("test".into()),
+        Error::StationNotFound {
+            station_code: "ABC".into(),
+        },
+        Error::McpProtocol("proto".into()),
+        Error::Cache("cache issue".into()),
+        Error::Internal(anyhow::anyhow!("internal")),
+        Error::RateLimited {
+            retry_after_seconds: Some(10),
+        },
+        Error::RateLimited {
+            retry_after_seconds: None,
+        },
+    ];
+
+    for err in &errors {
+        let msg = err.to_string();
+        assert!(!msg.is_empty(), "Error display should not be empty");
+    }
+}

--- a/tests/geographic_bounds_tests.rs
+++ b/tests/geographic_bounds_tests.rs
@@ -1,0 +1,97 @@
+//! Tests for GeographicBounds::contains and serialization.
+
+use velib_mcp::Coordinates;
+use velib_mcp::mcp::types::GeographicBounds;
+
+fn paris_bounds() -> GeographicBounds {
+    GeographicBounds {
+        north: 48.90,
+        south: 48.82,
+        east: 2.42,
+        west: 2.25,
+    }
+}
+
+#[test]
+fn contains_point_inside_bounds() {
+    let bounds = paris_bounds();
+    let inside = Coordinates::new(48.86, 2.35);
+    assert!(bounds.contains(&inside));
+}
+
+#[test]
+fn rejects_point_north_of_bounds() {
+    let bounds = paris_bounds();
+    let north = Coordinates::new(48.91, 2.35);
+    assert!(!bounds.contains(&north));
+}
+
+#[test]
+fn rejects_point_south_of_bounds() {
+    let bounds = paris_bounds();
+    let south = Coordinates::new(48.81, 2.35);
+    assert!(!bounds.contains(&south));
+}
+
+#[test]
+fn rejects_point_east_of_bounds() {
+    let bounds = paris_bounds();
+    let east = Coordinates::new(48.86, 2.43);
+    assert!(!bounds.contains(&east));
+}
+
+#[test]
+fn rejects_point_west_of_bounds() {
+    let bounds = paris_bounds();
+    let west = Coordinates::new(48.86, 2.24);
+    assert!(!bounds.contains(&west));
+}
+
+#[test]
+fn contains_point_on_north_boundary() {
+    let bounds = paris_bounds();
+    let on_edge = Coordinates::new(48.90, 2.35);
+    assert!(bounds.contains(&on_edge), "Points on the boundary should be included");
+}
+
+#[test]
+fn contains_point_on_south_boundary() {
+    let bounds = paris_bounds();
+    let on_edge = Coordinates::new(48.82, 2.35);
+    assert!(bounds.contains(&on_edge));
+}
+
+#[test]
+fn contains_point_on_east_boundary() {
+    let bounds = paris_bounds();
+    let on_edge = Coordinates::new(48.86, 2.42);
+    assert!(bounds.contains(&on_edge));
+}
+
+#[test]
+fn contains_point_on_west_boundary() {
+    let bounds = paris_bounds();
+    let on_edge = Coordinates::new(48.86, 2.25);
+    assert!(bounds.contains(&on_edge));
+}
+
+#[test]
+fn contains_all_four_corners() {
+    let bounds = paris_bounds();
+    assert!(bounds.contains(&Coordinates::new(48.90, 2.25))); // NW
+    assert!(bounds.contains(&Coordinates::new(48.90, 2.42))); // NE
+    assert!(bounds.contains(&Coordinates::new(48.82, 2.25))); // SW
+    assert!(bounds.contains(&Coordinates::new(48.82, 2.42))); // SE
+}
+
+#[test]
+fn geographic_bounds_serialization_roundtrip() {
+    let bounds = paris_bounds();
+    let json = serde_json::to_string(&bounds).unwrap();
+    let deserialized: GeographicBounds = serde_json::from_str(&json).unwrap();
+
+    assert!((deserialized.north - bounds.north).abs() < f64::EPSILON);
+    assert!((deserialized.south - bounds.south).abs() < f64::EPSILON);
+    assert!((deserialized.east - bounds.east).abs() < f64::EPSILON);
+    assert!((deserialized.west - bounds.west).abs() < f64::EPSILON);
+}

--- a/tests/mcp_jsonrpc_tests.rs
+++ b/tests/mcp_jsonrpc_tests.rs
@@ -1,0 +1,216 @@
+//! Tests for MCP server JSON-RPC request processing without spawning a
+//! separate process. Uses tower::ServiceExt::oneshot for in-process testing.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::Value;
+use tower::ServiceExt;
+use velib_mcp::mcp::server::McpServer;
+
+fn mcp_router() -> axum::Router {
+    McpServer::new().router()
+}
+
+async fn post_mcp(body: Value) -> (StatusCode, Value) {
+    let router = mcp_router();
+    let request = Request::builder()
+        .uri("/mcp")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body_bytes).unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn tools_list_returns_all_five_tools() {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    });
+    let (status, json) = post_mcp(body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["jsonrpc"], "2.0");
+    assert_eq!(json["id"], 1);
+
+    let tools = json["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 5, "Expected 5 MCP tools");
+
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"find_nearby_stations"));
+    assert!(names.contains(&"get_station_by_code"));
+    assert!(names.contains(&"search_stations_by_name"));
+    assert!(names.contains(&"get_area_statistics"));
+    assert!(names.contains(&"plan_bike_journey"));
+}
+
+#[tokio::test]
+async fn resources_list_returns_four_resources() {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "resources/list",
+        "params": {}
+    });
+    let (status, json) = post_mcp(body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let resources = json["result"]["resources"].as_array().unwrap();
+    assert_eq!(resources.len(), 4, "Expected 4 MCP resources");
+}
+
+#[tokio::test]
+async fn unknown_method_returns_error() {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "nonexistent/method",
+        "params": {}
+    });
+    let (status, json) = post_mcp(body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(json["error"].is_object(), "Should return a JSON-RPC error");
+    assert_eq!(json["error"]["code"], -32603);
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Unknown method"),
+        "Error message should mention unknown method"
+    );
+}
+
+#[tokio::test]
+async fn unknown_tool_returns_error() {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "nonexistent_tool",
+            "arguments": {}
+        }
+    });
+    let (status, json) = post_mcp(body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(json["error"].is_object());
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Unknown tool"),
+        "Error message should mention unknown tool"
+    );
+}
+
+#[tokio::test]
+async fn tools_call_without_name_returns_error() {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/call",
+        "params": {
+            "arguments": {}
+        }
+    });
+    let (status, json) = post_mcp(body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(json["error"].is_object(), "Missing tool name should produce an error");
+}
+
+#[tokio::test]
+async fn malformed_json_returns_parse_error() {
+    let router = mcp_router();
+    let request = Request::builder()
+        .uri("/mcp")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(b"this is not json".to_vec()))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(json["error"].is_object());
+    assert_eq!(json["error"]["code"], -32700, "Should be JSON-RPC parse error code");
+}
+
+#[tokio::test]
+async fn response_id_echoes_request_id() {
+    // String ID
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "my-request-id",
+        "method": "tools/list",
+        "params": {}
+    });
+    let (_, json) = post_mcp(body).await;
+    assert_eq!(json["id"], "my-request-id");
+
+    // Numeric ID
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 999,
+        "method": "tools/list",
+        "params": {}
+    });
+    let (_, json) = post_mcp(body).await;
+    assert_eq!(json["id"], 999);
+}
+
+#[tokio::test]
+async fn tools_have_required_schema_fields() {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    });
+    let (_, json) = post_mcp(body).await;
+
+    let tools = json["result"]["tools"].as_array().unwrap();
+    for tool in tools {
+        assert!(
+            tool["name"].is_string(),
+            "Tool missing 'name': {:?}",
+            tool
+        );
+        assert!(
+            tool["description"].is_string(),
+            "Tool missing 'description': {:?}",
+            tool
+        );
+        assert!(
+            tool["inputSchema"].is_object(),
+            "Tool missing 'inputSchema': {:?}",
+            tool
+        );
+        assert_eq!(
+            tool["inputSchema"]["type"], "object",
+            "inputSchema type should be 'object'"
+        );
+    }
+}

--- a/tests/types_edge_cases_tests.rs
+++ b/tests/types_edge_cases_tests.rs
@@ -1,0 +1,310 @@
+//! Edge-case and boundary tests for types.rs that are not covered by existing
+//! inline unit tests.
+
+use chrono::Utc;
+use velib_mcp::{
+    BikeAvailability, BikeTypeFilter, Coordinates, DataFreshness, RealTimeStatus,
+    ServiceCapabilities, StationReference, StationStatus, VelibStation,
+};
+
+// ---------------------------------------------------------------------------
+// Coordinates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distance_to_self_is_zero() {
+    let c = Coordinates::new(48.8566, 2.3522);
+    assert!(
+        c.distance_to(&c) < 0.01,
+        "Distance from a point to itself should be ~0"
+    );
+}
+
+#[test]
+fn distance_is_symmetric() {
+    let a = Coordinates::new(48.8566, 2.3522);
+    let b = Coordinates::new(48.8606, 2.3376);
+    let d1 = a.distance_to(&b);
+    let d2 = b.distance_to(&a);
+    assert!(
+        (d1 - d2).abs() < 0.01,
+        "Haversine distance should be symmetric: {d1} vs {d2}"
+    );
+}
+
+#[test]
+fn distance_across_antimeridian() {
+    // This isn't relevant for Paris, but validates the formula doesn't panic
+    // on extreme longitudes.
+    let a = Coordinates::new(0.0, 179.9);
+    let b = Coordinates::new(0.0, -179.9);
+    let d = a.distance_to(&b);
+    // ~22 km at the equator for 0.2 degrees
+    assert!(d > 0.0, "Distance should be positive");
+}
+
+#[test]
+fn paris_metro_boundary_checks() {
+    // Just inside each boundary
+    assert!(Coordinates::new(48.7, 2.0).is_valid_paris_metro());
+    assert!(Coordinates::new(49.0, 2.6).is_valid_paris_metro());
+
+    // Just outside each boundary
+    assert!(!Coordinates::new(48.699, 2.3).is_valid_paris_metro()); // south
+    assert!(!Coordinates::new(49.001, 2.3).is_valid_paris_metro()); // north
+    assert!(!Coordinates::new(48.85, 1.999).is_valid_paris_metro()); // west
+    assert!(!Coordinates::new(48.85, 2.601).is_valid_paris_metro()); // east
+}
+
+// ---------------------------------------------------------------------------
+// BikeAvailability
+// ---------------------------------------------------------------------------
+
+#[test]
+fn total_saturates_on_overflow() {
+    let bikes = BikeAvailability::new(u16::MAX, 1);
+    // saturating_add should cap at u16::MAX, not wrap around
+    assert_eq!(bikes.total(), u16::MAX);
+}
+
+#[test]
+fn total_of_max_values_saturates() {
+    let bikes = BikeAvailability::new(u16::MAX, u16::MAX);
+    assert_eq!(bikes.total(), u16::MAX);
+}
+
+#[test]
+fn default_bike_availability_has_no_bikes() {
+    let bikes = BikeAvailability::default();
+    assert_eq!(bikes.mechanical, 0);
+    assert_eq!(bikes.electric, 0);
+    assert!(!bikes.has_bikes());
+    assert!(!bikes.has_mechanical());
+    assert!(!bikes.has_electric());
+}
+
+#[test]
+fn has_mechanical_only() {
+    let bikes = BikeAvailability::new(1, 0);
+    assert!(bikes.has_mechanical());
+    assert!(!bikes.has_electric());
+    assert!(bikes.has_bikes());
+}
+
+#[test]
+fn has_electric_only() {
+    let bikes = BikeAvailability::new(0, 1);
+    assert!(!bikes.has_mechanical());
+    assert!(bikes.has_electric());
+    assert!(bikes.has_bikes());
+}
+
+// ---------------------------------------------------------------------------
+// DataFreshness boundary values
+// ---------------------------------------------------------------------------
+
+#[test]
+fn data_freshness_boundary_at_10_minutes() {
+    assert_eq!(DataFreshness::from_age(9.99), DataFreshness::Fresh);
+    assert_eq!(DataFreshness::from_age(10.0), DataFreshness::Recent);
+}
+
+#[test]
+fn data_freshness_boundary_at_30_minutes() {
+    assert_eq!(DataFreshness::from_age(29.99), DataFreshness::Recent);
+    assert_eq!(DataFreshness::from_age(30.0), DataFreshness::Stale);
+}
+
+#[test]
+fn data_freshness_boundary_at_120_minutes() {
+    assert_eq!(DataFreshness::from_age(119.99), DataFreshness::Stale);
+    assert_eq!(DataFreshness::from_age(120.0), DataFreshness::VeryStale);
+}
+
+#[test]
+fn data_freshness_negative_age_is_fresh() {
+    // Negative age (clock skew) should be treated as Fresh
+    assert_eq!(DataFreshness::from_age(-5.0), DataFreshness::Fresh);
+}
+
+#[test]
+fn data_freshness_zero_is_fresh() {
+    assert_eq!(DataFreshness::from_age(0.0), DataFreshness::Fresh);
+}
+
+// ---------------------------------------------------------------------------
+// StationReference::validate individual error paths
+// ---------------------------------------------------------------------------
+
+fn valid_reference() -> StationReference {
+    StationReference {
+        station_code: "12345".to_string(),
+        name: "Test Station".to_string(),
+        coordinates: Coordinates::new(48.8566, 2.3522),
+        capacity: 20,
+        capabilities: ServiceCapabilities::default(),
+    }
+}
+
+#[test]
+fn validate_rejects_empty_station_code() {
+    let mut r = valid_reference();
+    r.station_code = String::new();
+    let err = r.validate().unwrap_err();
+    assert!(
+        err.contains("Station code"),
+        "Expected station code error, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_empty_name() {
+    let mut r = valid_reference();
+    r.name = String::new();
+    let err = r.validate().unwrap_err();
+    assert!(
+        err.contains("Station name"),
+        "Expected station name error, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_zero_capacity() {
+    let mut r = valid_reference();
+    r.capacity = 0;
+    let err = r.validate().unwrap_err();
+    assert!(
+        err.contains("capacity"),
+        "Expected capacity error, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_capacity_over_200() {
+    let mut r = valid_reference();
+    r.capacity = 201;
+    let err = r.validate().unwrap_err();
+    assert!(
+        err.contains("unreasonably high"),
+        "Expected high capacity error, got: {err}"
+    );
+}
+
+#[test]
+fn validate_accepts_capacity_at_200() {
+    let mut r = valid_reference();
+    r.capacity = 200;
+    assert!(r.validate().is_ok());
+}
+
+#[test]
+fn validate_rejects_coordinates_outside_paris() {
+    let mut r = valid_reference();
+    r.coordinates = Coordinates::new(40.0, -74.0); // NYC
+    let err = r.validate().unwrap_err();
+    assert!(
+        err.contains("outside valid Paris"),
+        "Expected Paris bounds error, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// VelibStation behavior without real-time data
+// ---------------------------------------------------------------------------
+
+#[test]
+fn station_without_realtime_is_operational() {
+    let station = VelibStation::new(valid_reference());
+    assert!(station.is_operational());
+}
+
+#[test]
+fn station_without_realtime_has_no_available_bikes() {
+    let station = VelibStation::new(valid_reference());
+    assert!(!station.has_available_bikes(&BikeTypeFilter::AnyType));
+    assert!(!station.has_available_bikes(&BikeTypeFilter::MechanicalOnly));
+    assert!(!station.has_available_bikes(&BikeTypeFilter::ElectricOnly));
+}
+
+#[test]
+fn station_without_realtime_has_no_available_docks() {
+    let station = VelibStation::new(valid_reference());
+    assert!(!station.has_available_docks(1));
+    assert!(!station.has_available_docks(0));
+}
+
+#[test]
+fn station_without_realtime_validates_ok() {
+    let station = VelibStation::new(valid_reference());
+    assert!(station.validate().is_ok());
+}
+
+#[test]
+fn closed_station_is_not_operational() {
+    let station = VelibStation::new(valid_reference()).with_real_time(RealTimeStatus {
+        bikes: BikeAvailability::new(5, 3),
+        available_docks: 12,
+        status: StationStatus::Closed,
+        last_update: Utc::now(),
+        data_freshness: DataFreshness::Fresh,
+    });
+    assert!(!station.is_operational());
+}
+
+#[test]
+fn maintenance_station_is_not_operational() {
+    let station = VelibStation::new(valid_reference()).with_real_time(RealTimeStatus {
+        bikes: BikeAvailability::new(5, 3),
+        available_docks: 12,
+        status: StationStatus::Maintenance,
+        last_update: Utc::now(),
+        data_freshness: DataFreshness::Fresh,
+    });
+    assert!(!station.is_operational());
+}
+
+#[test]
+fn validate_catches_bikes_plus_docks_exceeding_capacity() {
+    let station = VelibStation {
+        reference: StationReference {
+            station_code: "V1".into(),
+            name: "Small Station".into(),
+            coordinates: Coordinates::new(48.8566, 2.3522),
+            capacity: 5,
+            capabilities: ServiceCapabilities::default(),
+        },
+        real_time: Some(RealTimeStatus {
+            bikes: BikeAvailability::new(3, 2),
+            available_docks: 1, // 3 + 2 + 1 = 6 > capacity 5
+            status: StationStatus::Open,
+            last_update: Utc::now(),
+            data_freshness: DataFreshness::Fresh,
+        }),
+    };
+    let err = station.validate().unwrap_err();
+    assert!(
+        err.contains("exceeds capacity"),
+        "Expected capacity exceeded error, got: {err}"
+    );
+}
+
+#[test]
+fn validate_accepts_bikes_plus_docks_equal_to_capacity() {
+    let station = VelibStation {
+        reference: StationReference {
+            station_code: "V2".into(),
+            name: "Full Station".into(),
+            coordinates: Coordinates::new(48.8566, 2.3522),
+            capacity: 10,
+            capabilities: ServiceCapabilities::default(),
+        },
+        real_time: Some(RealTimeStatus {
+            bikes: BikeAvailability::new(4, 3),
+            available_docks: 3, // 4 + 3 + 3 = 10 == capacity
+            status: StationStatus::Open,
+            last_update: Utc::now(),
+            data_freshness: DataFreshness::Fresh,
+        }),
+    };
+    assert!(station.validate().is_ok());
+}


### PR DESCRIPTION
## Summary\n\nAdds targeted unit and integration tests for components that had zero or shallow test coverage:\n\n- **`InMemoryCache` (src/data/cache.rs)**: Previously had **zero tests**. Now covered: insert/get/remove, TTL expiry, cleanup of stale entries, size tracking, clear, overwrite-refreshes-TTL, custom TTL override.\n- **`Error` MCP code mappings (src/error.rs)**: Validates that every error variant maps to the correct JSON-RPC error code (-32602, -32700, -32600, -32603, -32001) and that `error_type()` strings are unique snake_case.\n- **`GeographicBounds::contains`**: Boundary-inclusive checks for all four edges and corners, plus serialization roundtrip.\n- **Types edge cases**: `BikeAvailability::total()` saturating arithmetic at u16::MAX, `Coordinates::distance_to` identity/symmetry, `DataFreshness::from_age` exact boundary values (10/30/120 min), negative ages, `StationReference::validate` individual error paths, `VelibStation` behavior without real-time data, closed/maintenance station operational status.\n- **MCP JSON-RPC server**: In-process tests (via tower oneshot) for tools/list, resources/list, unknown method error, unknown tool error, missing tool name, malformed JSON parse error, request ID echo, and tool schema structure validation.\n\n## Test plan\n- [ ] `cargo test` passes (all new tests run without network access except where `#[ignore]` was already used)\n- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes\n- [ ] `cargo fmt --check` passes\n\nhttps://claude.ai/code/session_01NuHBW36UvTi7akwASQ5ZcH"