### PR TITLE
Remove unused MCP types from src/mcp/types.rs

### DIFF
--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -1,18 +1,5 @@
-use crate::types::{BikeTypeFilter, Coordinates, DataSource, VelibStation};
-use chrono::{DateTime, Utc};
+use crate::types::{BikeTypeFilter, Coordinates, VelibStation};
 use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GeographicQuery {
-    pub center: Coordinates,
-    pub radius_meters: u32,
-    #[serde(default = "default_limit")]
-    pub limit: u16,
-}
-
-fn default_limit() -> u16 {
-    50
-}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AvailabilityFilter {
@@ -28,42 +15,6 @@ pub struct AvailabilityFilter {
 
 fn default_true() -> bool {
     true
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StationQuery {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub geographic: Option<GeographicQuery>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub availability: Option<AvailabilityFilter>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub station_codes: Option<Vec<String>>,
-    #[serde(default = "default_true")]
-    pub include_real_time: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PaginationInfo {
-    pub offset: usize,
-    pub limit: usize,
-    pub has_more: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ResponseMetadata {
-    pub response_time: DateTime<Utc>,
-    pub processing_time_ms: u64,
-    pub real_time_source: DataSource,
-    pub reference_source: DataSource,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StationListResponse {
-    pub stations: Vec<VelibStation>,
-    pub total_count: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pagination: Option<PaginationInfo>,
-    pub metadata: ResponseMetadata,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Removes five types from `src/mcp/types.rs` that are defined but never referenced anywhere in handlers, server code, or tests:

- `StationQuery`
- `PaginationInfo`
- `ResponseMetadata`
- `StationListResponse`
- `GeographicQuery` (along with its helper `default_limit`)

Also removes the now-unnecessary `use chrono::{DateTime, Utc};` and `use crate::types::DataSource;` imports that were only used by the removed types.

**Impact**: ~45 lines removed. No behavioral change -- these types had zero usages.

## Test plan

- [ ] `cargo test` passes (no code references these types)
- [ ] `cargo clippy` passes
- [ ] `cargo fmt --check` passes