### PR TITLE
Extract shared find_available_port test helper

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,10 @@
+use std::net::TcpListener;
+
+/// Find an available port by binding to a random port and returning it
+pub fn find_available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("Failed to bind to ephemeral port")
+        .local_addr()
+        .expect("Failed to get local address")
+        .port()
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,21 +1,13 @@
-use std::net::TcpListener;
+mod common;
+
 use std::process::Command;
 use std::time::Duration;
 use tokio::time::sleep;
 
-/// Find an available port by binding to a random port and returning it
-fn find_available_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("Failed to bind to ephemeral port")
-        .local_addr()
-        .expect("Failed to get local address")
-        .port()
-}
-
 #[tokio::test]
 async fn test_claude_installation_workflow() {
     // Test that the binary runs with custom port
-    let port = find_available_port();
+    let port = common::find_available_port();
     let mut server = Command::new(env!("CARGO_BIN_EXE_velib-mcp"))
         .env("IP", "127.0.0.1")
         .env("PORT", port.to_string())
@@ -69,7 +61,7 @@ async fn test_claude_installation_workflow() {
 #[ignore = "requires live network access to Velib API"]
 async fn test_velib_tool_functionality() {
     // Start server
-    let port = find_available_port();
+    let port = common::find_available_port();
     let mut server = Command::new(env!("CARGO_BIN_EXE_velib-mcp"))
         .env("IP", "127.0.0.1")
         .env("PORT", port.to_string())

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -1,21 +1,13 @@
-use std::net::TcpListener;
+mod common;
+
 use std::process::Command;
 use std::time::Duration;
 use tokio::time::sleep;
 
-/// Find an available port by binding to a random port and returning it
-fn find_available_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("Failed to bind to ephemeral port")
-        .local_addr()
-        .expect("Failed to get local address")
-        .port()
-}
-
 #[tokio::test]
 async fn test_server_starts_and_responds() {
     // Start the server in background
-    let port = find_available_port();
+    let port = common::find_available_port();
     let mut server = Command::new(env!("CARGO_BIN_EXE_velib-mcp"))
         .env("IP", "127.0.0.1")
         .env("PORT", port.to_string())
@@ -53,7 +45,7 @@ async fn test_server_starts_and_responds() {
 #[tokio::test]
 async fn test_mcp_tools_endpoint() {
     // Start the server
-    let port = find_available_port();
+    let port = common::find_available_port();
     let mut server = Command::new(env!("CARGO_BIN_EXE_velib-mcp"))
         .env("IP", "127.0.0.1")
         .env("PORT", port.to_string())


### PR DESCRIPTION
## Summary

The `find_available_port()` function was duplicated identically in both `tests/smoke_test.rs` and `tests/integration_test.rs`. This PR:

- Extracts the shared helper into `tests/common/mod.rs`
- Updates both test files to use `mod common;` and `common::find_available_port()`
- Removes the duplicated function definitions and their `use std::net::TcpListener;` imports

**Impact**: ~14 lines removed, single source of truth for test utilities.

## Test plan

- [ ] `cargo test` passes (both smoke and integration tests still use the helper correctly)
- [ ] `cargo clippy` passes
- [ ] `cargo fmt --check` passes