### PR TITLE
Extract duplicated HTTP response checking into check_response helper

### DIFF
--- a/src/data/retry.rs
+++ b/src/data/retry.rs
@@ -280,6 +280,31 @@ impl RetryableHttpClient {
         }
     }
 
+    /// Check an HTTP response for rate limiting and error status codes.
+    /// Returns the response on success, or an appropriate error.
+    fn check_response(response: reqwest::Response, url: &str) -> Result<reqwest::Response> {
+        debug!("Received response: {} {}", response.status(), url);
+
+        if response.status() == 429 {
+            let retry_after = extract_retry_after_from_response(&response);
+            warn!(
+                "Rate limited (429) for {}{}",
+                url,
+                retry_after.map_or_else(String::new, |seconds| format!(
+                    ", retry after {seconds}s"
+                ))
+            );
+            return Err(create_rate_limited_error(&response));
+        }
+
+        if !response.status().is_success() {
+            warn!("HTTP error {} for {}", response.status(), url);
+            return Err(Error::Http(response.error_for_status().unwrap_err()));
+        }
+
+        Ok(response)
+    }
+
     /// Make a GET request with retry logic
     pub async fn get(&self, url: &str) -> Result<reqwest::Response> {
         debug!("Making GET request to: {}", url);
@@ -287,29 +312,7 @@ impl RetryableHttpClient {
         self.retry_policy
             .execute(|| async {
                 let response = self.client.get(url).send().await?;
-
-                debug!("Received response: {} {}", response.status(), url);
-
-                // Check for rate limiting
-                if response.status() == 429 {
-                    let retry_after = extract_retry_after_from_response(&response);
-                    warn!(
-                        "Rate limited (429) for {}{}",
-                        url,
-                        retry_after.map_or_else(String::new, |seconds| format!(
-                            ", retry after {seconds}s"
-                        ))
-                    );
-                    return Err(create_rate_limited_error(&response));
-                }
-
-                // Check for other HTTP errors
-                if !response.status().is_success() {
-                    warn!("HTTP error {} for {}", response.status(), url);
-                    return Err(Error::Http(response.error_for_status().unwrap_err()));
-                }
-
-                Ok(response)
+                Self::check_response(response, url)
             })
             .await
     }
@@ -324,29 +327,7 @@ impl RetryableHttpClient {
         self.retry_policy
             .execute(|| async {
                 let response = self.client.get(url).query(query).send().await?;
-
-                debug!("Received response: {} {}", response.status(), url);
-
-                // Check for rate limiting
-                if response.status() == 429 {
-                    let retry_after = extract_retry_after_from_response(&response);
-                    warn!(
-                        "Rate limited (429) for {}{}",
-                        url,
-                        retry_after.map_or_else(String::new, |seconds| format!(
-                            ", retry after {seconds}s"
-                        ))
-                    );
-                    return Err(create_rate_limited_error(&response));
-                }
-
-                // Check for other HTTP errors
-                if !response.status().is_success() {
-                    warn!("HTTP error {} for {}", response.status(), url);
-                    return Err(Error::Http(response.error_for_status().unwrap_err()));
-                }
-
-                Ok(response)
+                Self::check_response(response, url)
             })
             .await
     }

--- a/src/data/retry.rs
+++ b/src/data/retry.rs
@@ -290,9 +290,7 @@ impl RetryableHttpClient {
             warn!(
                 "Rate limited (429) for {}{}",
                 url,
-                retry_after.map_or_else(String::new, |seconds| format!(
-                    ", retry after {seconds}s"
-                ))
+                retry_after.map_or_else(String::new, |seconds| format!(", retry after {seconds}s"))
             );
             return Err(create_rate_limited_error(&response));
         }


### PR DESCRIPTION
## Summary

`RetryableHttpClient::get()` and `RetryableHttpClient::get_with_query()` contained identical ~15-line blocks for:
1. Logging the response status
2. Detecting 429 rate-limit responses and constructing the appropriate error
3. Detecting non-success HTTP statuses and converting them to errors

This PR extracts that logic into a single `check_response()` method and calls it from both `get()` and `get_with_query()`, reducing each method to just the request construction + the shared check.

**Impact**: ~20 lines removed. The response-checking behavior is unchanged -- same logging, same error types, same control flow.

## Test plan

- [ ] `cargo test` passes (all existing retry and HTTP tests still pass)
- [ ] `cargo clippy` passes
- [ ] `cargo fmt --check` passes