### PR TITLE
ci: sort Cargo files, auto-apply clippy, add license compliance

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+cargo clippy --fix --all-features --all-targets --allow-dirty --allow-staged
+cargo fmt --all
+cargo sort
+git add Cargo.toml
+cargo deny check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,27 @@
+[licenses]
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "ISC",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "Unicode-DFS-2016",
+  "CC0-1.0",
+  "Zlib",
+  "OpenSSL",
+]
+private = { ignore = true }
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-org = { github = ["dominicburkart"] }


### PR DESCRIPTION
## Issues addressed

- Closes #22 — enforce `cargo sort` at commit and in CI
- Closes #23 — pre-commit hook auto-applies `clippy --fix`
- Closes #29 — license compliance via `cargo deny`

## What changed

### `.cargo-husky/hooks/pre-commit` (new file — #22, #23, #29)

A new pre-commit hook is created at `.cargo-husky/hooks/pre-commit`. cargo-husky is already listed as a dev-dependency in `Cargo.toml`, so this hook will be installed automatically on `cargo test` / `cargo build`. The hook runs:

1. `cargo clippy --fix --all-features --all-targets --allow-dirty --allow-staged` — auto-fixes clippy lints (the `--allow-dirty`/`--allow-staged` flags are required because files are already staged when the hook runs)
2. `cargo fmt --all` — enforces formatting
3. `cargo sort` — sorts `Cargo.toml` dependency sections
4. `git add Cargo.toml` — re-stages `Cargo.toml` after sort modifies it
5. `cargo deny check` — blocks commits that introduce disallowed licenses

### `deny.toml` (new file — #29)

Configures `cargo-deny` for license compliance. Allows MIT, Apache-2.0 (and LLVM variant), ISC, BSD-2-Clause, BSD-3-Clause, Unicode-DFS-2016, CC0-1.0, Zlib, and OpenSSL. Includes a clarify stanza for the `ring` crate. Sets `multiple-versions = "warn"` and restricts sources to known registries and the `dominicburkart` GitHub org.

### `.github/workflows/ci.yml` (needs manual update — #22, #29)

> **Note:** The MCP integration does not have `workflows` write permission, so this file could not be pushed automatically. The diff below must be applied manually (or via a token with `workflow` scope).

Two new jobs to add to `ci.yml`, plus updating the `build` job's `needs` list:

```yaml
  cargo-sort:
    name: Cargo Sort
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: dtolnay/rust-toolchain@stable
      - name: Install cargo-sort
        run: cargo install cargo-sort --locked
      - name: Check Cargo.toml sort order
        run: cargo sort --check

  deny:
    name: License Compliance
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: EmbarkStudios/cargo-deny-action@v2
        with:
          command: check
          arguments: --all-features
```

Update the `build` job's `needs` to gate on the new jobs:
```yaml
  build:
    needs: [test, fmt, clippy, security, feature-testing, cargo-sort, deny]
```

## Test plan

- [ ] Run `cargo test` locally — this installs the hook via cargo-husky
- [ ] Make a test commit with unsorted/unformatted/lint-dirty code and confirm the hook auto-fixes and blocks or patches as expected
- [ ] Run `cargo sort --check` locally to confirm `Cargo.toml` already satisfies the check (or sort it first)
- [ ] Run `cargo deny check` locally to confirm all current dependencies pass the license allowlist
- [ ] Apply the `ci.yml` workflow changes manually and confirm the two new CI jobs pass on this branch

https://claude.ai/code/session_014a7iJ4HFPTyXv5vKRUiVoB