### PR TITLE
refactor: remove unnecessary &mut self from data client, add cache cleanup

### DIFF
--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -67,7 +67,7 @@ impl VelibDataClient {
     }
 
     /// Fetch all station reference data
-    pub async fn fetch_reference_stations(&mut self) -> Result<Vec<StationReference>> {
+    pub async fn fetch_reference_stations(&self) -> Result<Vec<StationReference>> {
         const CACHE_KEY: &str = "all_reference_stations";
 
         // Check cache first
@@ -125,7 +125,7 @@ impl VelibDataClient {
     }
 
     /// Fetch real-time station status data
-    pub async fn fetch_realtime_status(&mut self) -> Result<HashMap<String, RealTimeStatus>> {
+    pub async fn fetch_realtime_status(&self) -> Result<HashMap<String, RealTimeStatus>> {
         const CACHE_KEY: &str = "all_realtime_status";
 
         // Check cache first
@@ -183,7 +183,7 @@ impl VelibDataClient {
     }
 
     /// Get all stations with optional real-time data
-    pub async fn get_all_stations(&mut self, include_realtime: bool) -> Result<Vec<VelibStation>> {
+    pub async fn get_all_stations(&self, include_realtime: bool) -> Result<Vec<VelibStation>> {
         let reference_stations = self.fetch_reference_stations().await?;
 
         if !include_realtime {
@@ -211,7 +211,7 @@ impl VelibDataClient {
 
     /// Get a specific station by code
     pub async fn get_station_by_code(
-        &mut self,
+        &self,
         station_code: &str,
         include_realtime: bool,
     ) -> Result<Option<VelibStation>> {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1,3 +1,5 @@
+use std::time::Duration as StdDuration;
+
 use unicode_normalization::UnicodeNormalization;
 
 use crate::data::VelibDataClient;
@@ -36,9 +38,29 @@ impl Default for McpToolHandler {
 impl McpToolHandler {
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            data_client: Arc::new(RwLock::new(VelibDataClient::new())),
-        }
+        let data_client = Arc::new(RwLock::new(VelibDataClient::new()));
+
+        // Spawn a background task to clean up expired cache entries every 5 minutes.
+        // We hold only a weak reference so that the task does not prevent the Arc from
+        // being dropped when the handler is no longer used.
+        let weak = Arc::downgrade(&data_client);
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(StdDuration::from_secs(5 * 60));
+            interval.tick().await; // skip the immediate first tick
+            loop {
+                interval.tick().await;
+                match weak.upgrade() {
+                    Some(client) => {
+                        let guard = client.read().await;
+                        guard.cleanup_cache().await;
+                    }
+                    None => break, // handler has been dropped; exit task
+                }
+            }
+        });
+
+        Self { data_client }
     }
 
     #[must_use]
@@ -84,7 +106,7 @@ impl McpToolHandler {
         }
 
         // Fetch live station data
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         // Filter stations by distance and bike type
@@ -143,7 +165,7 @@ impl McpToolHandler {
         &self,
         input: GetStationByCodeInput,
     ) -> Result<GetStationByCodeOutput> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let station = data_client
             .get_station_by_code(&input.station_code, true)
             .await?;
@@ -172,7 +194,7 @@ impl McpToolHandler {
         }
 
         // Fetch live station data and search by name
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         let query_normalized = input.query.to_lowercase().nfc().collect::<String>();
@@ -218,7 +240,7 @@ impl McpToolHandler {
         input: GetAreaStatisticsInput,
     ) -> Result<GetAreaStatisticsOutput> {
         // Fetch live station data
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         // Filter stations within the specified bounds
@@ -305,7 +327,7 @@ impl McpToolHandler {
         }
 
         // Find nearby stations for pickup and dropoff using live data
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         // Get preferences or use defaults
@@ -411,7 +433,7 @@ impl McpToolHandler {
 
     /// Get reference stations for resource endpoints
     pub async fn get_reference_stations(&self) -> Result<Vec<crate::types::StationReference>> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         data_client.fetch_reference_stations().await
     }
 
@@ -419,7 +441,7 @@ impl McpToolHandler {
     pub async fn get_realtime_status(
         &self,
     ) -> Result<std::collections::HashMap<String, crate::types::RealTimeStatus>> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         data_client.fetch_realtime_status().await
     }
 
@@ -428,13 +450,13 @@ impl McpToolHandler {
         &self,
         include_realtime: bool,
     ) -> Result<Vec<crate::types::VelibStation>> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         data_client.get_all_stations(include_realtime).await
     }
 
     /// Test connectivity to data sources for health checks
     pub async fn test_connectivity(&self) -> Result<()> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         // Simple connectivity test by fetching reference data
         data_client.get_all_stations(false).await?;
         Ok(())

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1,5 +1,7 @@
-use std::time::Duration as StdDuration;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
+use tokio::sync::RwLock;
 use unicode_normalization::UnicodeNormalization;
 
 use crate::data::VelibDataClient;
@@ -12,9 +14,6 @@ use crate::mcp::types::{
 };
 use crate::types::{BikeTypeFilter, Coordinates, VelibStation};
 use crate::{Error, Result};
-use std::sync::Arc;
-use std::time::Instant;
-use tokio::sync::RwLock;
 
 const MAX_SEARCH_RADIUS: u32 = 5000; // 5km
 const MAX_RESULT_LIMIT: u16 = 100;
@@ -45,8 +44,7 @@ impl McpToolHandler {
         // being dropped when the handler is no longer used.
         let weak = Arc::downgrade(&data_client);
         tokio::spawn(async move {
-            let mut interval =
-                tokio::time::interval(StdDuration::from_secs(5 * 60));
+            let mut interval = tokio::time::interval(Duration::from_secs(5 * 60));
             interval.tick().await; // skip the immediate first tick
             loop {
                 interval.tick().await;
@@ -399,7 +397,8 @@ impl McpToolHandler {
             let pickup_walk_ratio = f64::from(best_pickup.straight_line_distance_meters) / max_walk;
             let dropoff_walk_ratio =
                 f64::from(best_dropoff.straight_line_distance_meters) / max_walk;
-            let confidence_score = 1.0 - f64::midpoint(pickup_walk_ratio, dropoff_walk_ratio) * 0.5;
+            let confidence_score =
+                1.0 - f64::midpoint(pickup_walk_ratio, dropoff_walk_ratio) * 0.5;
 
             recommendations.push(JourneyRecommendation {
                 pickup_station: best_pickup.station.clone(),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

### 1. Remove unnecessary `&mut self` from `VelibDataClient`

`InMemoryCache<K, V>` wraps its storage in `Arc<RwLock<HashMap<...>>>`, giving it interior mutability. This means the four public data-fetching methods on `VelibDataClient` — `fetch_reference_stations`, `fetch_realtime_status`, `get_all_stations`, and `get_station_by_code` — never actually mutate the struct through the `self` reference; all mutations go through the lock inside the cache. Declaring them `&mut self` was therefore a false constraint.

**Before:** callers (including `McpToolHandler`) had to acquire an *exclusive write lock* on `Arc<RwLock<VelibDataClient>>` even for pure cache reads.

**After:** the methods take `&self`, so callers can hold a *shared read lock* instead. With `tokio::sync::RwLock` this means multiple concurrent requests can read (and serve) cached station data simultaneously without blocking each other, rather than serialising behind a single writer lock.

All nine `self.data_client.write().await` / `let mut data_client` sites in `McpToolHandler` are updated to `self.data_client.read().await` / `let data_client`.

### 2. Schedule automatic cache cleanup

`InMemoryCache::cleanup_expired()` existed but was never called automatically, meaning entries that have passed their TTL accumulate indefinitely in the `HashMap`. In a long-running server this leads to unbounded memory growth proportional to the number of distinct cache keys inserted over time.

`McpToolHandler::new()` now spawns a background `tokio` task that calls `cleanup_cache()` every 5 minutes. The task holds only a `Weak` reference to the `Arc<RwLock<VelibDataClient>>`, so it does not artificially extend the handler's lifetime: when the last strong `Arc` is dropped the weak upgrade returns `None` and the task exits cleanly.

## Test plan

- [x] `cargo check` passes with zero errors
- [x] Full `cargo test` suite passes (44 tests, 8 ignored as network-dependent)
- [x] Pre-push hook re-runs the full suite and confirms green

EOF
)