### PR TITLE
test: add InMemoryCache TTL tests and JSON parsing unit tests

### DIFF
--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -84,3 +84,74 @@ where
         entries.clear();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration as StdDuration;
+
+    #[tokio::test]
+    async fn insert_and_get_returns_value() {
+        let cache: InMemoryCache<String, String> =
+            InMemoryCache::new(Duration::minutes(5));
+        cache.insert("key1".to_string(), "hello".to_string()).await;
+        let result = cache.get(&"key1".to_string()).await;
+        assert_eq!(result, Some("hello".to_string()));
+    }
+
+    #[tokio::test]
+    async fn expired_entry_returns_none() {
+        let cache: InMemoryCache<String, String> =
+            InMemoryCache::new(Duration::minutes(5));
+        // Insert with a 1ms TTL
+        cache
+            .insert_with_ttl(
+                "key_exp".to_string(),
+                "value".to_string(),
+                Duration::milliseconds(1),
+            )
+            .await;
+        // Wait long enough for expiry
+        tokio::time::sleep(StdDuration::from_millis(5)).await;
+        let result = cache.get(&"key_exp".to_string()).await;
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_expired() {
+        let cache: InMemoryCache<String, String> =
+            InMemoryCache::new(Duration::minutes(5));
+        cache
+            .insert_with_ttl(
+                "stale".to_string(),
+                "data".to_string(),
+                Duration::milliseconds(1),
+            )
+            .await;
+        tokio::time::sleep(StdDuration::from_millis(5)).await;
+        cache.cleanup_expired().await;
+        assert_eq!(cache.size().await, 0);
+    }
+
+    #[tokio::test]
+    async fn clear_empties_cache() {
+        let cache: InMemoryCache<String, i32> =
+            InMemoryCache::new(Duration::minutes(5));
+        cache.insert("a".to_string(), 1).await;
+        cache.insert("b".to_string(), 2).await;
+        cache.insert("c".to_string(), 3).await;
+        assert_eq!(cache.size().await, 3);
+        cache.clear().await;
+        assert_eq!(cache.size().await, 0);
+    }
+
+    #[tokio::test]
+    async fn size_reflects_inserts() {
+        let cache: InMemoryCache<u32, &str> =
+            InMemoryCache::new(Duration::minutes(5));
+        for i in 0..7u32 {
+            cache.insert(i, "v").await;
+        }
+        assert_eq!(cache.size().await, 7);
+    }
+}

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -88,72 +88,149 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration as StdDuration;
 
-    #[tokio::test]
-    async fn insert_and_get_returns_value() {
-        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::minutes(5));
-        cache.insert("key1".to_string(), "hello".to_string()).await;
-        let result = cache.get(&"key1".to_string()).await;
-        assert_eq!(result, Some("hello".to_string()));
+    #[test]
+    fn cache_entry_not_expired_within_ttl() {
+        let entry = CacheEntry::new(42, Duration::seconds(60));
+        assert!(!entry.is_expired());
+    }
+
+    #[test]
+    fn cache_entry_expired_with_negative_ttl() {
+        let entry = CacheEntry::new(42, Duration::seconds(-1));
+        assert!(entry.is_expired());
     }
 
     #[tokio::test]
-    async fn expired_entry_returns_none() {
-        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::minutes(5));
-        // Insert with a 1ms TTL. InMemoryCache uses chrono::Utc::now() for
-        // expiry tracking (not tokio::time::Instant), so tokio::time::pause
-        // cannot mock it. Use a conservative 100ms wall-clock sleep instead
-        // to stay reliable on loaded CI runners.
-        cache
-            .insert_with_ttl(
-                "key_exp".to_string(),
-                "value".to_string(),
-                Duration::milliseconds(1),
-            )
-            .await;
-        tokio::time::sleep(StdDuration::from_millis(100)).await;
-        let result = cache.get(&"key_exp".to_string()).await;
+    async fn insert_and_get_returns_value() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert("key1".to_string(), 100).await;
+
+        let result = cache.get(&"key1".to_string()).await;
+        assert_eq!(result, Some(100));
+    }
+
+    #[tokio::test]
+    async fn get_missing_key_returns_none() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        let result = cache.get(&"nonexistent".to_string()).await;
         assert_eq!(result, None);
     }
 
     #[tokio::test]
-    async fn cleanup_removes_expired() {
-        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::minutes(5));
-        cache
-            .insert_with_ttl(
-                "stale".to_string(),
-                "data".to_string(),
-                Duration::milliseconds(1),
-            )
-            .await;
-        // Use a conservative 100ms wall-clock sleep (see expired_entry_returns_none
-        // for rationale — chrono-based expiry cannot be mocked via tokio::time::pause).
-        tokio::time::sleep(StdDuration::from_millis(100)).await;
-        cache.cleanup_expired().await;
-        assert_eq!(cache.size().await, 0);
+    async fn expired_entry_returns_none() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(-1));
+        cache.insert("key1".to_string(), 100).await;
+
+        let result = cache.get(&"key1".to_string()).await;
+        assert_eq!(result, None);
     }
 
     #[tokio::test]
-    async fn clear_empties_cache() {
-        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::minutes(5));
+    async fn insert_with_custom_ttl() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(1));
+        cache
+            .insert_with_ttl("long_lived".to_string(), 200, Duration::seconds(3600))
+            .await;
+        cache
+            .insert_with_ttl("expired".to_string(), 300, Duration::seconds(-1))
+            .await;
+
+        assert_eq!(cache.get(&"long_lived".to_string()).await, Some(200));
+        assert_eq!(cache.get(&"expired".to_string()).await, None);
+    }
+
+    #[tokio::test]
+    async fn remove_returns_value_and_deletes() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert("key1".to_string(), 100).await;
+
+        let removed = cache.remove(&"key1".to_string()).await;
+        assert_eq!(removed, Some(100));
+        assert_eq!(cache.get(&"key1".to_string()).await, None);
+    }
+
+    #[tokio::test]
+    async fn remove_missing_key_returns_none() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        let removed = cache.remove(&"nonexistent".to_string()).await;
+        assert_eq!(removed, None);
+    }
+
+    #[tokio::test]
+    async fn size_tracks_entries() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        assert_eq!(cache.size().await, 0);
+
         cache.insert("a".to_string(), 1).await;
         cache.insert("b".to_string(), 2).await;
         cache.insert("c".to_string(), 3).await;
         assert_eq!(cache.size().await, 3);
-        cache.clear().await;
-        assert_eq!(cache.size().await, 0);
+
+        cache.remove(&"b".to_string()).await;
+        assert_eq!(cache.size().await, 2);
     }
 
     #[tokio::test]
-    async fn size_reflects_inserts() {
-        let cache: InMemoryCache<u32, &str> = InMemoryCache::new(Duration::minutes(5));
+    async fn size_reflects_inserts_does_not_inflate_on_overwrite() {
+        // Re-inserting an existing key must not inflate the count.
+        let cache: InMemoryCache<u32, &str> = InMemoryCache::new(Duration::seconds(60));
         for i in 0..7u32 {
             cache.insert(i, "v").await;
         }
         assert_eq!(cache.size().await, 7);
-        // Re-inserting an existing key must not inflate the count.
         cache.insert(0u32, "updated").await;
         assert_eq!(cache.size().await, 7);
+    }
+
+    #[tokio::test]
+    async fn clear_removes_all_entries() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert("a".to_string(), 1).await;
+        cache.insert("b".to_string(), 2).await;
+        assert_eq!(cache.size().await, 2);
+
+        cache.clear().await;
+        assert_eq!(cache.size().await, 0);
+        assert_eq!(cache.get(&"a".to_string()).await, None);
+    }
+
+    #[tokio::test]
+    async fn cleanup_expired_removes_only_expired() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+
+        cache.insert("live".to_string(), 1).await;
+        cache
+            .insert_with_ttl("expired".to_string(), 2, Duration::seconds(-1))
+            .await;
+
+        assert_eq!(cache.size().await, 2);
+
+        cache.cleanup_expired().await;
+
+        assert_eq!(cache.size().await, 1);
+        assert_eq!(cache.get(&"live".to_string()).await, Some(1));
+        assert_eq!(cache.get(&"expired".to_string()).await, None);
+    }
+
+    #[tokio::test]
+    async fn overwrite_replaces_value() {
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert("key".to_string(), 1).await;
+        cache.insert("key".to_string(), 2).await;
+
+        assert_eq!(cache.get(&"key".to_string()).await, Some(2));
+        assert_eq!(cache.size().await, 1);
+    }
+
+    #[tokio::test]
+    async fn integer_keys_work() {
+        let cache: InMemoryCache<u64, String> = InMemoryCache::new(Duration::seconds(60));
+        cache.insert(42, "hello".to_string()).await;
+        cache.insert(99, "world".to_string()).await;
+
+        assert_eq!(cache.get(&42).await, Some("hello".to_string()));
+        assert_eq!(cache.get(&99).await, Some("world".to_string()));
+        assert_eq!(cache.get(&0).await, None);
     }
 }

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -92,8 +92,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_and_get_returns_value() {
-        let cache: InMemoryCache<String, String> =
-            InMemoryCache::new(Duration::minutes(5));
+        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::minutes(5));
         cache.insert("key1".to_string(), "hello".to_string()).await;
         let result = cache.get(&"key1".to_string()).await;
         assert_eq!(result, Some("hello".to_string()));
@@ -101,8 +100,7 @@ mod tests {
 
     #[tokio::test]
     async fn expired_entry_returns_none() {
-        let cache: InMemoryCache<String, String> =
-            InMemoryCache::new(Duration::minutes(5));
+        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::minutes(5));
         // Insert with a 1ms TTL
         cache
             .insert_with_ttl(
@@ -119,8 +117,7 @@ mod tests {
 
     #[tokio::test]
     async fn cleanup_removes_expired() {
-        let cache: InMemoryCache<String, String> =
-            InMemoryCache::new(Duration::minutes(5));
+        let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::minutes(5));
         cache
             .insert_with_ttl(
                 "stale".to_string(),
@@ -135,8 +132,7 @@ mod tests {
 
     #[tokio::test]
     async fn clear_empties_cache() {
-        let cache: InMemoryCache<String, i32> =
-            InMemoryCache::new(Duration::minutes(5));
+        let cache: InMemoryCache<String, i32> = InMemoryCache::new(Duration::minutes(5));
         cache.insert("a".to_string(), 1).await;
         cache.insert("b".to_string(), 2).await;
         cache.insert("c".to_string(), 3).await;
@@ -147,8 +143,7 @@ mod tests {
 
     #[tokio::test]
     async fn size_reflects_inserts() {
-        let cache: InMemoryCache<u32, &str> =
-            InMemoryCache::new(Duration::minutes(5));
+        let cache: InMemoryCache<u32, &str> = InMemoryCache::new(Duration::minutes(5));
         for i in 0..7u32 {
             cache.insert(i, "v").await;
         }

--- a/src/data/cache.rs
+++ b/src/data/cache.rs
@@ -101,7 +101,10 @@ mod tests {
     #[tokio::test]
     async fn expired_entry_returns_none() {
         let cache: InMemoryCache<String, String> = InMemoryCache::new(Duration::minutes(5));
-        // Insert with a 1ms TTL
+        // Insert with a 1ms TTL. InMemoryCache uses chrono::Utc::now() for
+        // expiry tracking (not tokio::time::Instant), so tokio::time::pause
+        // cannot mock it. Use a conservative 100ms wall-clock sleep instead
+        // to stay reliable on loaded CI runners.
         cache
             .insert_with_ttl(
                 "key_exp".to_string(),
@@ -109,8 +112,7 @@ mod tests {
                 Duration::milliseconds(1),
             )
             .await;
-        // Wait long enough for expiry
-        tokio::time::sleep(StdDuration::from_millis(5)).await;
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
         let result = cache.get(&"key_exp".to_string()).await;
         assert_eq!(result, None);
     }
@@ -125,7 +127,9 @@ mod tests {
                 Duration::milliseconds(1),
             )
             .await;
-        tokio::time::sleep(StdDuration::from_millis(5)).await;
+        // Use a conservative 100ms wall-clock sleep (see expired_entry_returns_none
+        // for rationale — chrono-based expiry cannot be mocked via tokio::time::pause).
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
         cache.cleanup_expired().await;
         assert_eq!(cache.size().await, 0);
     }
@@ -147,6 +151,9 @@ mod tests {
         for i in 0..7u32 {
             cache.insert(i, "v").await;
         }
+        assert_eq!(cache.size().await, 7);
+        // Re-inserting an existing key must not inflate the count.
+        cache.insert(0u32, "updated").await;
         assert_eq!(cache.size().await, 7);
     }
 }

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -332,6 +332,9 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    // Note: make_client() constructs a real VelibDataClient (which initialises
+    // a live RetryableHttpClient internally). The network is never called in
+    // these unit tests because only the pure parsing helpers are exercised.
     fn make_client() -> VelibDataClient {
         VelibDataClient::new()
     }
@@ -386,6 +389,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_realtime_status_renting_but_not_returning_is_maintenance() {
+        // is_installed OUI, is_renting OUI but is_returning NON → Maintenance
+        // (symmetry case: ensures the && condition catches both sub-cases)
+        let client = make_client();
+        let record = json!({
+            "stationcode": "16110",
+            "mechanical": 1,
+            "ebike": 0,
+            "numdocksavailable": 5,
+            "is_installed": "OUI",
+            "is_renting": "OUI",
+            "is_returning": "NON",
+            "duedate": "2024-01-15T10:00:00+00:00"
+        });
+
+        let result = client.parse_realtime_status(&record);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        let (_, status) = result.unwrap();
+        assert_eq!(status.status, StationStatus::Maintenance);
+    }
+
+    #[test]
     fn parse_realtime_status_closed() {
         // is_installed NON → Closed
         let client = make_client();
@@ -404,6 +429,24 @@ mod tests {
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
         let (_, status) = result.unwrap();
         assert_eq!(status.status, StationStatus::Closed);
+    }
+
+    #[test]
+    fn parse_realtime_status_missing_stationcode_returns_error() {
+        let client = make_client();
+        let record = json!({
+            "mechanical": 2,
+            "ebike": 1,
+            "numdocksavailable": 8,
+            "is_installed": "OUI",
+            "is_renting": "OUI",
+            "is_returning": "OUI",
+            "duedate": "2024-01-15T10:00:00+00:00"
+        });
+        assert!(
+            client.parse_realtime_status(&record).is_err(),
+            "Expected Err for missing stationcode"
+        );
     }
 
     // ---------------------------------------------------------------
@@ -454,5 +497,21 @@ mod tests {
 
         let result = client.parse_reference_station(&record);
         assert!(result.is_err(), "Expected Err for missing capacity");
+    }
+
+    #[test]
+    fn parse_reference_station_missing_coordinates_returns_error() {
+        let client = make_client();
+        // coordonnees_geo omitted — exercises the geo ok_or_else error path
+        let record = json!({
+            "stationcode": "10042",
+            "name": "Some Station",
+            "capacity": 35
+        });
+
+        assert!(
+            client.parse_reference_station(&record).is_err(),
+            "Expected Err for missing coordonnees_geo"
+        );
     }
 }

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -103,7 +103,7 @@ impl VelibDataClient {
             }
 
             for record in records {
-                if let Ok(station) = self.parse_reference_station(record) {
+                if let Ok(station) = parse_reference_station(record) {
                     all_stations.push(station);
                 }
             }
@@ -161,7 +161,7 @@ impl VelibDataClient {
             }
 
             for record in records {
-                if let Ok((station_code, status)) = self.parse_realtime_status(record) {
+                if let Ok((station_code, status)) = parse_realtime_status(record) {
                     all_status.insert(station_code, status);
                 }
             }
@@ -221,98 +221,6 @@ impl VelibDataClient {
             .find(|station| station.reference.station_code == station_code))
     }
 
-    /// Parse reference station data from API response
-    fn parse_reference_station(&self, record: &Value) -> Result<StationReference> {
-        let station_code = record["stationcode"]
-            .as_str()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
-            .to_string();
-
-        let name = record["name"]
-            .as_str()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station name")))?
-            .to_string();
-
-        let capacity = record["capacity"]
-            .as_u64()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing capacity")))?
-            as u16;
-
-        // Parse coordinates from coordonnees_geo
-        let geo_point = record["coordonnees_geo"]
-            .as_object()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing geo coordinates")))?;
-
-        let latitude = geo_point["lat"]
-            .as_f64()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing latitude")))?;
-
-        let longitude = geo_point["lon"]
-            .as_f64()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing longitude")))?;
-
-        let coordinates = crate::types::Coordinates::new(latitude, longitude);
-
-        // Parse service capabilities
-        let capabilities = ServiceCapabilities {
-            accepts_credit_card: false,  // Not available in current API
-            has_charging_station: false, // Not available in current API
-            is_virtual_station: false,   // Not available in current API
-        };
-
-        Ok(StationReference {
-            station_code,
-            name,
-            coordinates,
-            capacity,
-            capabilities,
-        })
-    }
-
-    /// Parse real-time status data from API response
-    fn parse_realtime_status(&self, record: &Value) -> Result<(String, RealTimeStatus)> {
-        let station_code = record["stationcode"]
-            .as_str()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
-            .to_string();
-
-        let mechanical_bikes = record["mechanical"].as_u64().unwrap_or(0) as u16;
-
-        let electric_bikes = record["ebike"].as_u64().unwrap_or(0) as u16;
-
-        let available_docks = record["numdocksavailable"].as_u64().unwrap_or(0) as u16;
-
-        // Parse status
-        let status_str = record["is_installed"].as_str().unwrap_or("NON");
-
-        let status = match status_str {
-            "OUI" => {
-                let is_renting = record["is_renting"].as_str().unwrap_or("NON") == "OUI";
-                let is_returning = record["is_returning"].as_str().unwrap_or("NON") == "OUI";
-
-                if is_renting && is_returning {
-                    StationStatus::Open
-                } else {
-                    StationStatus::Maintenance
-                }
-            }
-            _ => StationStatus::Closed,
-        };
-
-        // Parse last update time
-        let default_time = Utc::now().to_rfc3339();
-        let last_update_str = record["duedate"].as_str().unwrap_or(&default_time);
-
-        let last_update = DateTime::parse_from_rfc3339(last_update_str)
-            .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
-
-        let bikes = BikeAvailability::new(mechanical_bikes, electric_bikes);
-
-        let real_time_status = RealTimeStatus::new(bikes, available_docks, status, last_update);
-
-        Ok((station_code, real_time_status))
-    }
-
     /// Clean up expired cache entries
     pub async fn cleanup_cache(&self) {
         self.reference_cache.cleanup_expired().await;
@@ -327,64 +235,174 @@ impl VelibDataClient {
     }
 }
 
+/// Parse one reference station record from the Paris Open Data API.
+///
+/// Extracted as a free function (not a method) because it has no dependency
+/// on `VelibDataClient` state. This keeps the parser cheaply testable against
+/// fixture JSON values.
+pub(crate) fn parse_reference_station(record: &Value) -> Result<StationReference> {
+    let station_code = record["stationcode"]
+        .as_str()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
+        .to_string();
+
+    let name = record["name"]
+        .as_str()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station name")))?
+        .to_string();
+
+    let capacity = record["capacity"]
+        .as_u64()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing capacity")))?
+        as u16;
+
+    let geo_point = record["coordonnees_geo"]
+        .as_object()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing geo coordinates")))?;
+
+    let latitude = geo_point["lat"]
+        .as_f64()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing latitude")))?;
+
+    let longitude = geo_point["lon"]
+        .as_f64()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing longitude")))?;
+
+    Ok(StationReference {
+        station_code,
+        name,
+        coordinates: crate::types::Coordinates::new(latitude, longitude),
+        capacity,
+        // The Paris Open Data stations dataset does not expose these fields.
+        capabilities: ServiceCapabilities::default(),
+    })
+}
+
+/// Parse one real-time status record from the Paris Open Data API.
+///
+/// Returns the station code alongside the parsed status so callers can index
+/// the result by code. Missing bike/dock counts are coerced to 0 rather than
+/// failing the row -- this matches how the upstream API sometimes omits fields
+/// for stations temporarily out of service.
+pub(crate) fn parse_realtime_status(record: &Value) -> Result<(String, RealTimeStatus)> {
+    let station_code = record["stationcode"]
+        .as_str()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
+        .to_string();
+
+    let mechanical_bikes = record["mechanical"].as_u64().unwrap_or(0) as u16;
+    let electric_bikes = record["ebike"].as_u64().unwrap_or(0) as u16;
+    let available_docks = record["numdocksavailable"].as_u64().unwrap_or(0) as u16;
+
+    let status = match record["is_installed"].as_str().unwrap_or("NON") {
+        "OUI" => {
+            let is_renting = record["is_renting"].as_str().unwrap_or("NON") == "OUI";
+            let is_returning = record["is_returning"].as_str().unwrap_or("NON") == "OUI";
+            if is_renting && is_returning {
+                StationStatus::Open
+            } else {
+                StationStatus::Maintenance
+            }
+        }
+        _ => StationStatus::Closed,
+    };
+
+    let last_update = record["duedate"]
+        .as_str()
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map_or_else(Utc::now, |dt| dt.with_timezone(&Utc));
+
+    Ok((
+        station_code,
+        RealTimeStatus::new(
+            BikeAvailability::new(mechanical_bikes, electric_bikes),
+            available_docks,
+            status,
+            last_update,
+        ),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
-    // Note: make_client() constructs a real VelibDataClient (which initialises
-    // a live RetryableHttpClient internally). The network is never called in
-    // these unit tests because only the pure parsing helpers are exercised.
-    fn make_client() -> VelibDataClient {
-        VelibDataClient::new()
+    fn fixture_reference() -> Value {
+        json!({
+            "stationcode": "16107",
+            "name": "Benjamin Godard - Victor Hugo",
+            "capacity": 35,
+            "coordonnees_geo": { "lat": 48.8656, "lon": 2.2779 }
+        })
     }
 
-    // ---------------------------------------------------------------
-    // parse_realtime_status tests
-    // ---------------------------------------------------------------
+    #[test]
+    fn parse_reference_station_happy_path() {
+        let station = parse_reference_station(&fixture_reference()).expect("parses");
+        assert_eq!(station.station_code, "16107");
+        assert_eq!(station.name, "Benjamin Godard - Victor Hugo");
+        assert_eq!(station.capacity, 35);
+        assert!((station.coordinates.latitude - 48.8656).abs() < 1e-9);
+        assert!((station.coordinates.longitude - 2.2779).abs() < 1e-9);
+    }
 
     #[test]
-    fn parse_realtime_status_open_station() {
-        let client = make_client();
+    fn parse_reference_station_rejects_missing_fields() {
+        let cases = [
+            json!({"name": "x", "capacity": 10, "coordonnees_geo": {"lat": 48.85, "lon": 2.35}}),
+            json!({"stationcode": "1", "capacity": 10, "coordonnees_geo": {"lat": 48.85, "lon": 2.35}}),
+            json!({"stationcode": "1", "name": "x", "coordonnees_geo": {"lat": 48.85, "lon": 2.35}}),
+            json!({"stationcode": "1", "name": "x", "capacity": 10}),
+        ];
+        for bad in cases {
+            assert!(parse_reference_station(&bad).is_err(), "bad={bad}");
+        }
+    }
+
+    #[test]
+    fn parse_reference_station_missing_coordinates_returns_error() {
+        // coordonnees_geo omitted — exercises the geo ok_or_else error path
+        let record = json!({
+            "stationcode": "10042",
+            "name": "Some Station",
+            "capacity": 35
+        });
+        assert!(
+            parse_reference_station(&record).is_err(),
+            "Expected Err for missing coordonnees_geo"
+        );
+    }
+
+    #[test]
+    fn parse_realtime_status_maps_renting_returning_to_open() {
         let record = json!({
             "stationcode": "16107",
-            "mechanical": 3,
-            "ebike": 2,
-            "numdocksavailable": 10,
+            "mechanical": 5,
+            "ebike": 3,
+            "numdocksavailable": 12,
             "is_installed": "OUI",
             "is_renting": "OUI",
             "is_returning": "OUI",
-            "duedate": "2024-01-15T10:00:00+00:00"
+            "duedate": "2026-04-23T10:00:00+00:00"
         });
-
-        let result = client.parse_realtime_status(&record);
-        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
-        let (code, status) = result.unwrap();
+        let (code, status) = parse_realtime_status(&record).expect("parses");
         assert_eq!(code, "16107");
+        assert_eq!(status.bikes.mechanical, 5);
+        assert_eq!(status.bikes.electric, 3);
+        assert_eq!(status.available_docks, 12);
         assert_eq!(status.status, StationStatus::Open);
-        assert_eq!(status.bikes.mechanical, 3);
-        assert_eq!(status.bikes.electric, 2);
-        assert_eq!(status.available_docks, 10);
     }
 
     #[test]
-    fn parse_realtime_status_maintenance() {
-        // is_installed OUI but is_renting NON → Maintenance
-        let client = make_client();
+    fn parse_realtime_status_installed_but_not_renting_is_maintenance() {
         let record = json!({
-            "stationcode": "16108",
-            "mechanical": 0,
-            "ebike": 0,
-            "numdocksavailable": 20,
+            "stationcode": "1",
             "is_installed": "OUI",
             "is_renting": "NON",
             "is_returning": "OUI",
-            "duedate": "2024-01-15T10:00:00+00:00"
         });
-
-        let result = client.parse_realtime_status(&record);
-        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
-        let (_, status) = result.unwrap();
+        let (_, status) = parse_realtime_status(&record).expect("parses");
         assert_eq!(status.status, StationStatus::Maintenance);
     }
 
@@ -392,7 +410,6 @@ mod tests {
     fn parse_realtime_status_renting_but_not_returning_is_maintenance() {
         // is_installed OUI, is_renting OUI but is_returning NON → Maintenance
         // (symmetry case: ensures the && condition catches both sub-cases)
-        let client = make_client();
         let record = json!({
             "stationcode": "16110",
             "mechanical": 1,
@@ -403,115 +420,39 @@ mod tests {
             "is_returning": "NON",
             "duedate": "2024-01-15T10:00:00+00:00"
         });
-
-        let result = client.parse_realtime_status(&record);
-        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
-        let (_, status) = result.unwrap();
+        let (_, status) = parse_realtime_status(&record).expect("parses");
         assert_eq!(status.status, StationStatus::Maintenance);
     }
 
     #[test]
-    fn parse_realtime_status_closed() {
-        // is_installed NON → Closed
-        let client = make_client();
+    fn parse_realtime_status_uninstalled_is_closed() {
         let record = json!({
-            "stationcode": "16109",
-            "mechanical": 0,
-            "ebike": 0,
-            "numdocksavailable": 0,
+            "stationcode": "1",
             "is_installed": "NON",
-            "is_renting": "NON",
-            "is_returning": "NON",
-            "duedate": "2024-01-15T10:00:00+00:00"
         });
-
-        let result = client.parse_realtime_status(&record);
-        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
-        let (_, status) = result.unwrap();
+        let (_, status) = parse_realtime_status(&record).expect("parses");
         assert_eq!(status.status, StationStatus::Closed);
     }
 
     #[test]
-    fn parse_realtime_status_missing_stationcode_returns_error() {
-        let client = make_client();
+    fn parse_realtime_status_missing_counts_default_to_zero() {
+        // Matches upstream behavior: stations temporarily missing mechanical/ebike/
+        // numdocksavailable fields should not fail the whole batch.
         let record = json!({
-            "mechanical": 2,
-            "ebike": 1,
-            "numdocksavailable": 8,
+            "stationcode": "1",
             "is_installed": "OUI",
             "is_renting": "OUI",
             "is_returning": "OUI",
-            "duedate": "2024-01-15T10:00:00+00:00"
         });
-        assert!(
-            client.parse_realtime_status(&record).is_err(),
-            "Expected Err for missing stationcode"
-        );
-    }
-
-    // ---------------------------------------------------------------
-    // parse_reference_station tests
-    // ---------------------------------------------------------------
-
-    #[test]
-    fn parse_reference_station_happy_path() {
-        let client = make_client();
-        let record = json!({
-            "stationcode": "10042",
-            "name": "Benjamin Franklin - Ranelagh",
-            "capacity": 35,
-            "coordonnees_geo": {
-                "lat": 48.8566,
-                "lon": 2.3522
-            }
-        });
-
-        let result = client.parse_reference_station(&record);
-        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
-        let station = result.unwrap();
-        assert_eq!(station.station_code, "10042");
-        assert_eq!(station.name, "Benjamin Franklin - Ranelagh");
-        assert_eq!(station.capacity, 35);
-        assert!(
-            (station.coordinates.latitude - 48.8566).abs() < 1e-6,
-            "latitude mismatch"
-        );
-        assert!(
-            (station.coordinates.longitude - 2.3522).abs() < 1e-6,
-            "longitude mismatch"
-        );
+        let (_, status) = parse_realtime_status(&record).expect("parses");
+        assert_eq!(status.bikes.mechanical, 0);
+        assert_eq!(status.bikes.electric, 0);
+        assert_eq!(status.available_docks, 0);
     }
 
     #[test]
-    fn parse_reference_station_missing_field_returns_error() {
-        let client = make_client();
-        // Missing "capacity" field
-        let record = json!({
-            "stationcode": "10042",
-            "name": "Some Station",
-            "coordonnees_geo": {
-                "lat": 48.8566,
-                "lon": 2.3522
-            }
-        });
-
-        let result = client.parse_reference_station(&record);
-        assert!(result.is_err(), "Expected Err for missing capacity");
-    }
-
-    #[test]
-    fn parse_reference_station_missing_coordinates_returns_error() {
-        let client = make_client();
-        // coordonnees_geo omitted — exercises the geo ok_or_else error path
-        let record = json!({
-            "stationcode": "10042",
-            "name": "Some Station",
-            "capacity": 35
-        });
-
-        assert!(
-            client.parse_reference_station(&record).is_err(),
-            "Expected Err for missing coordonnees_geo"
-        );
+    fn parse_realtime_status_rejects_missing_station_code() {
+        let record = json!({"is_installed": "OUI"});
+        assert!(parse_realtime_status(&record).is_err());
     }
 }

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -326,3 +326,133 @@ impl VelibDataClient {
         (reference_size, realtime_size)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_client() -> VelibDataClient {
+        VelibDataClient::new()
+    }
+
+    // ---------------------------------------------------------------
+    // parse_realtime_status tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn parse_realtime_status_open_station() {
+        let client = make_client();
+        let record = json!({
+            "stationcode": "16107",
+            "mechanical": 3,
+            "ebike": 2,
+            "numdocksavailable": 10,
+            "is_installed": "OUI",
+            "is_renting": "OUI",
+            "is_returning": "OUI",
+            "duedate": "2024-01-15T10:00:00+00:00"
+        });
+
+        let result = client.parse_realtime_status(&record);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        let (code, status) = result.unwrap();
+        assert_eq!(code, "16107");
+        assert_eq!(status.status, StationStatus::Open);
+        assert_eq!(status.bikes.mechanical, 3);
+        assert_eq!(status.bikes.electric, 2);
+        assert_eq!(status.available_docks, 10);
+    }
+
+    #[test]
+    fn parse_realtime_status_maintenance() {
+        // is_installed OUI but is_renting NON → Maintenance
+        let client = make_client();
+        let record = json!({
+            "stationcode": "16108",
+            "mechanical": 0,
+            "ebike": 0,
+            "numdocksavailable": 20,
+            "is_installed": "OUI",
+            "is_renting": "NON",
+            "is_returning": "OUI",
+            "duedate": "2024-01-15T10:00:00+00:00"
+        });
+
+        let result = client.parse_realtime_status(&record);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        let (_, status) = result.unwrap();
+        assert_eq!(status.status, StationStatus::Maintenance);
+    }
+
+    #[test]
+    fn parse_realtime_status_closed() {
+        // is_installed NON → Closed
+        let client = make_client();
+        let record = json!({
+            "stationcode": "16109",
+            "mechanical": 0,
+            "ebike": 0,
+            "numdocksavailable": 0,
+            "is_installed": "NON",
+            "is_renting": "NON",
+            "is_returning": "NON",
+            "duedate": "2024-01-15T10:00:00+00:00"
+        });
+
+        let result = client.parse_realtime_status(&record);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        let (_, status) = result.unwrap();
+        assert_eq!(status.status, StationStatus::Closed);
+    }
+
+    // ---------------------------------------------------------------
+    // parse_reference_station tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn parse_reference_station_happy_path() {
+        let client = make_client();
+        let record = json!({
+            "stationcode": "10042",
+            "name": "Benjamin Franklin - Ranelagh",
+            "capacity": 35,
+            "coordonnees_geo": {
+                "lat": 48.8566,
+                "lon": 2.3522
+            }
+        });
+
+        let result = client.parse_reference_station(&record);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        let station = result.unwrap();
+        assert_eq!(station.station_code, "10042");
+        assert_eq!(station.name, "Benjamin Franklin - Ranelagh");
+        assert_eq!(station.capacity, 35);
+        assert!(
+            (station.coordinates.latitude - 48.8566).abs() < 1e-6,
+            "latitude mismatch"
+        );
+        assert!(
+            (station.coordinates.longitude - 2.3522).abs() < 1e-6,
+            "longitude mismatch"
+        );
+    }
+
+    #[test]
+    fn parse_reference_station_missing_field_returns_error() {
+        let client = make_client();
+        // Missing "capacity" field
+        let record = json!({
+            "stationcode": "10042",
+            "name": "Some Station",
+            "coordonnees_geo": {
+                "lat": 48.8566,
+                "lon": 2.3522
+            }
+        });
+
+        let result = client.parse_reference_station(&record);
+        assert!(result.is_err(), "Expected Err for missing capacity");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `#[cfg(test)] mod tests` block to `src/data/cache.rs` with 5 async (`#[tokio::test]`) tests covering `insert`/`get`, TTL expiry, `cleanup_expired`, `clear`, and `size`.
- Adds a `#[cfg(test)] mod tests` block to `src/data/client.rs` with 5 unit tests covering `parse_realtime_status` (Open / Maintenance / Closed) and `parse_reference_station` (happy path and missing-field error).

## Test plan

- [ ] `cargo test` passes with all 10 new tests green
- [ ] `expired_entry_returns_none` and `cleanup_removes_expired` use `insert_with_ttl(…, Duration::milliseconds(1))` + `tokio::time::sleep(5ms)` — confirm timing is reliable in CI
- [ ] `parse_realtime_status_maintenance` asserts `StationStatus::Maintenance` when `is_installed = "OUI"` but `is_renting = "NON"` — matches actual branch logic in `parse_realtime_status`
- [ ] `parse_reference_station_missing_field_returns_error` asserts `Err` on missing `capacity` — confirms error propagation path