### PR TITLE
[velib-mcp] Architecture: eliminate pagination duplication and unify coordinate validation

### DIFF
--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -15,8 +15,11 @@ const VELIB_STATIONS_URL: &str = "https://opendata.paris.fr/api/explore/v2.1/cat
 const VELIB_REALTIME_URL: &str = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/records";
 
 // Cache TTLs
-const REFERENCE_CACHE_TTL_MINUTES: i64 = 5; // 5 minutes for reference data
-const REALTIME_CACHE_TTL_MINUTES: i64 = 2; // 2 minutes for real-time data
+const REFERENCE_CACHE_TTL_MINUTES: i64 = 5;
+const REALTIME_CACHE_TTL_MINUTES: i64 = 2;
+
+// Number of records requested per API page
+const API_PAGE_SIZE: usize = 100;
 
 #[derive(Debug)]
 pub struct VelibDataClient {
@@ -66,11 +69,53 @@ impl VelibDataClient {
         }
     }
 
+    /// Fetch all pages from a paginated API endpoint, calling `parse_record` on each item.
+    ///
+    /// Records that fail to parse are silently skipped (logged upstream callers can add
+    /// tracing if needed).  Returns when a page comes back with fewer items than the page
+    /// size, signalling the last page.
+    async fn fetch_paginated<T, F>(&self, url: &str, mut parse_record: F) -> Result<Vec<T>>
+    where
+        F: FnMut(&Value) -> Result<T>,
+    {
+        let mut results = Vec::new();
+        let mut offset = 0;
+
+        loop {
+            let query_params = &[
+                ("limit", &API_PAGE_SIZE.to_string()),
+                ("offset", &offset.to_string()),
+            ];
+
+            let response = self.client.get_with_query(url, query_params).await?;
+            let json: Value = response.json().await?;
+            let records = json["results"]
+                .as_array()
+                .ok_or_else(|| Error::Internal(anyhow::anyhow!("Invalid API response format")))?;
+
+            if records.is_empty() {
+                break;
+            }
+
+            for record in records {
+                if let Ok(item) = parse_record(record) {
+                    results.push(item);
+                }
+            }
+
+            offset += API_PAGE_SIZE;
+            if records.len() < API_PAGE_SIZE {
+                break;
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Fetch all station reference data
     pub async fn fetch_reference_stations(&mut self) -> Result<Vec<StationReference>> {
         const CACHE_KEY: &str = "all_reference_stations";
 
-        // Check cache first
         if let Some(cached) = self.reference_cache.get(&CACHE_KEY.to_string()).await {
             debug!("Using cached reference stations: {} stations", cached.len());
             return Ok(cached);
@@ -78,57 +123,22 @@ impl VelibDataClient {
 
         info!("Fetching reference stations from Paris Open Data API");
 
-        let mut all_stations = Vec::new();
-        let mut offset = 0;
-        let limit = 100; // API limit
+        let stations = self
+            .fetch_paginated(VELIB_STATIONS_URL, |r| self.parse_reference_station(r))
+            .await?;
 
-        loop {
-            let query_params = &[
-                ("limit", &limit.to_string()),
-                ("offset", &offset.to_string()),
-            ];
-
-            let response = self
-                .client
-                .get_with_query(VELIB_STATIONS_URL, query_params)
-                .await?;
-
-            let json: Value = response.json().await?;
-            let records = json["results"]
-                .as_array()
-                .ok_or_else(|| Error::Internal(anyhow::anyhow!("Invalid API response format")))?;
-
-            if records.is_empty() {
-                break; // No more records
-            }
-
-            for record in records {
-                if let Ok(station) = self.parse_reference_station(record) {
-                    all_stations.push(station);
-                }
-            }
-
-            offset += limit;
-            if records.len() < limit {
-                break; // Last page
-            }
-        }
-
-        info!("Fetched {} reference stations", all_stations.len());
-
-        // Cache the results
+        info!("Fetched {} reference stations", stations.len());
         self.reference_cache
-            .insert(CACHE_KEY.to_string(), all_stations.clone())
+            .insert(CACHE_KEY.to_string(), stations.clone())
             .await;
 
-        Ok(all_stations)
+        Ok(stations)
     }
 
     /// Fetch real-time station status data
     pub async fn fetch_realtime_status(&mut self) -> Result<HashMap<String, RealTimeStatus>> {
         const CACHE_KEY: &str = "all_realtime_status";
 
-        // Check cache first
         if let Some(cached) = self.realtime_cache.get(&CACHE_KEY.to_string()).await {
             debug!("Using cached real-time status: {} stations", cached.len());
             return Ok(cached);
@@ -136,45 +146,13 @@ impl VelibDataClient {
 
         info!("Fetching real-time status from Paris Open Data API");
 
-        let mut all_status = HashMap::new();
-        let mut offset = 0;
-        let limit = 100; // API limit
+        let pairs = self
+            .fetch_paginated(VELIB_REALTIME_URL, |r| self.parse_realtime_status(r))
+            .await?;
 
-        loop {
-            let query_params = &[
-                ("limit", &limit.to_string()),
-                ("offset", &offset.to_string()),
-            ];
-
-            let response = self
-                .client
-                .get_with_query(VELIB_REALTIME_URL, query_params)
-                .await?;
-
-            let json: Value = response.json().await?;
-            let records = json["results"]
-                .as_array()
-                .ok_or_else(|| Error::Internal(anyhow::anyhow!("Invalid API response format")))?;
-
-            if records.is_empty() {
-                break; // No more records
-            }
-
-            for record in records {
-                if let Ok((station_code, status)) = self.parse_realtime_status(record) {
-                    all_status.insert(station_code, status);
-                }
-            }
-
-            offset += limit;
-            if records.len() < limit {
-                break; // Last page
-            }
-        }
+        let all_status: HashMap<String, RealTimeStatus> = pairs.into_iter().collect();
 
         info!("Fetched real-time status for {} stations", all_status.len());
-
-        // Cache the results
         self.realtime_cache
             .insert(CACHE_KEY.to_string(), all_status.clone())
             .await;
@@ -238,7 +216,6 @@ impl VelibDataClient {
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing capacity")))?
             as u16;
 
-        // Parse coordinates from coordonnees_geo
         let geo_point = record["coordonnees_geo"]
             .as_object()
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing geo coordinates")))?;
@@ -251,21 +228,12 @@ impl VelibDataClient {
             .as_f64()
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing longitude")))?;
 
-        let coordinates = crate::types::Coordinates::new(latitude, longitude);
-
-        // Parse service capabilities
-        let capabilities = ServiceCapabilities {
-            accepts_credit_card: false,  // Not available in current API
-            has_charging_station: false, // Not available in current API
-            is_virtual_station: false,   // Not available in current API
-        };
-
         Ok(StationReference {
             station_code,
             name,
-            coordinates,
+            coordinates: crate::types::Coordinates::new(latitude, longitude),
             capacity,
-            capabilities,
+            capabilities: ServiceCapabilities::default(),
         })
     }
 
@@ -277,19 +245,13 @@ impl VelibDataClient {
             .to_string();
 
         let mechanical_bikes = record["mechanical"].as_u64().unwrap_or(0) as u16;
-
         let electric_bikes = record["ebike"].as_u64().unwrap_or(0) as u16;
-
         let available_docks = record["numdocksavailable"].as_u64().unwrap_or(0) as u16;
 
-        // Parse status
-        let status_str = record["is_installed"].as_str().unwrap_or("NON");
-
-        let status = match status_str {
+        let status = match record["is_installed"].as_str().unwrap_or("NON") {
             "OUI" => {
                 let is_renting = record["is_renting"].as_str().unwrap_or("NON") == "OUI";
                 let is_returning = record["is_returning"].as_str().unwrap_or("NON") == "OUI";
-
                 if is_renting && is_returning {
                     StationStatus::Open
                 } else {
@@ -299,18 +261,16 @@ impl VelibDataClient {
             _ => StationStatus::Closed,
         };
 
-        // Parse last update time
-        let default_time = Utc::now().to_rfc3339();
-        let last_update_str = record["duedate"].as_str().unwrap_or(&default_time);
-
-        let last_update = DateTime::parse_from_rfc3339(last_update_str)
-            .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
+        let last_update = record["duedate"]
+            .as_str()
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map_or_else(Utc::now, |dt| dt.with_timezone(&Utc));
 
         let bikes = BikeAvailability::new(mechanical_bikes, electric_bikes);
-
-        let real_time_status = RealTimeStatus::new(bikes, available_docks, status, last_update);
-
-        Ok((station_code, real_time_status))
+        Ok((
+            station_code,
+            RealTimeStatus::new(bikes, available_docks, status, last_update),
+        ))
     }
 
     /// Clean up expired cache entries

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -48,13 +48,29 @@ impl McpToolHandler {
         }
     }
 
+    /// Validate that coordinates are within the Paris metro bounding box and the
+    /// 50 km service radius around Paris City Hall.  Returns an appropriate error
+    /// variant on failure so callers can return it directly.
+    fn validate_paris_coordinates(coords: &Coordinates) -> Result<()> {
+        if !coords.is_valid_paris_metro() {
+            return Err(Error::InvalidCoordinates {
+                latitude: coords.latitude,
+                longitude: coords.longitude,
+            });
+        }
+        if !coords.is_within_paris_service_area() {
+            let distance_km = coords.distance_to(&PARIS_CITY_HALL) / 1000.0;
+            return Err(Error::OutsideServiceArea { distance_km });
+        }
+        Ok(())
+    }
+
     pub async fn find_nearby_stations(
         &self,
         input: FindNearbyStationsInput,
     ) -> Result<FindNearbyStationsOutput> {
         let start_time = Instant::now();
 
-        // Validate input parameters
         if input.radius_meters > MAX_SEARCH_RADIUS {
             return Err(Error::SearchRadiusTooLarge {
                 radius: input.radius_meters,
@@ -70,61 +86,41 @@ impl McpToolHandler {
         }
 
         let query_point = Coordinates::new(input.latitude, input.longitude);
-        if !query_point.is_valid_paris_metro() {
-            return Err(Error::InvalidCoordinates {
-                latitude: input.latitude,
-                longitude: input.longitude,
-            });
-        }
+        Self::validate_paris_coordinates(&query_point)?;
 
-        // Enforce 50km distance limit from Paris City Hall
-        if !query_point.is_within_paris_service_area() {
-            let distance_km = query_point.distance_to(&PARIS_CITY_HALL) / 1000.0;
-            return Err(Error::OutsideServiceArea { distance_km });
-        }
-
-        // Fetch live station data
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        // Filter stations by distance and bike type
         let mut nearby_stations: Vec<StationWithDistance> = all_stations
             .into_iter()
             .filter_map(|station| {
                 let distance = query_point.distance_to(&station.reference.coordinates) as u32;
 
-                // Check if within search radius
-                if distance <= input.radius_meters {
-                    // Check if station has the requested bike type (if specified)
-                    let has_requested_bikes = match &input.availability_filter {
-                        Some(filter) => match &filter.bike_type {
-                            Some(bike_type) => station.has_available_bikes(bike_type),
-                            None => true,
-                        },
-                        None => true, // No filter specified
-                    };
+                if distance > input.radius_meters {
+                    return None;
+                }
 
-                    if has_requested_bikes && station.is_operational() {
-                        Some(StationWithDistance {
-                            station,
-                            straight_line_distance_meters: distance,
-                        })
-                    } else {
-                        None
-                    }
+                let has_requested_bikes = match &input.availability_filter {
+                    Some(filter) => match &filter.bike_type {
+                        Some(bike_type) => station.has_available_bikes(bike_type),
+                        None => true,
+                    },
+                    None => true,
+                };
+
+                if has_requested_bikes && station.is_operational() {
+                    Some(StationWithDistance {
+                        station,
+                        straight_line_distance_meters: distance,
+                    })
                 } else {
                     None
                 }
             })
             .collect();
 
-        // Sort by distance
         nearby_stations.sort_by_key(|s| s.straight_line_distance_meters);
-
-        // Limit results
         nearby_stations.truncate(input.limit as usize);
-
-        let stations = nearby_stations;
 
         let search_time = start_time.elapsed().as_millis() as u64;
 
@@ -132,10 +128,10 @@ impl McpToolHandler {
             search_metadata: SearchMetadata {
                 query_point,
                 radius_meters: input.radius_meters,
-                total_found: stations.len() as u32,
+                total_found: nearby_stations.len() as u32,
                 search_time_ms: search_time,
             },
-            stations,
+            stations: nearby_stations,
         })
     }
 
@@ -145,7 +141,7 @@ impl McpToolHandler {
     ) -> Result<GetStationByCodeOutput> {
         let mut data_client = self.data_client.write().await;
         let station = data_client
-            .get_station_by_code(&input.station_code, true)
+            .get_station_by_code(&input.station_code, input.include_real_time)
             .await?;
 
         Ok(GetStationByCodeOutput {
@@ -171,7 +167,6 @@ impl McpToolHandler {
             });
         }
 
-        // Fetch live station data and search by name
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
@@ -193,23 +188,19 @@ impl McpToolHandler {
             })
             .collect();
 
-        // Sort by name for consistent results
         matching_stations.sort_by(|a, b| a.reference.name.cmp(&b.reference.name));
-
-        // Limit results
         matching_stations.truncate(input.limit as usize);
 
-        let stations = matching_stations;
         let search_time = start_time.elapsed().as_millis() as u64;
 
         Ok(SearchStationsByNameOutput {
             search_metadata: TextSearchMetadata {
                 query: input.query,
-                total_found: stations.len() as u32,
+                total_found: matching_stations.len() as u32,
                 fuzzy_enabled: input.fuzzy,
                 search_time_ms: search_time,
             },
-            stations,
+            stations: matching_stations,
         })
     }
 
@@ -217,17 +208,14 @@ impl McpToolHandler {
         &self,
         input: GetAreaStatisticsInput,
     ) -> Result<GetAreaStatisticsOutput> {
-        // Fetch live station data
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        // Filter stations within the specified bounds
         let area_stations: Vec<&VelibStation> = all_stations
             .iter()
             .filter(|station| input.bounds.contains(&station.reference.coordinates))
             .collect();
 
-        // Calculate area statistics from live data
         let total_stations = area_stations.len() as u32;
         let operational_stations = area_stations
             .iter()
@@ -256,21 +244,19 @@ impl McpToolHandler {
             0.0
         };
 
-        let stats = AreaStatistics {
-            total_stations,
-            operational_stations,
-            total_capacity,
-            available_bikes: AvailableBikesStats {
-                mechanical: total_mechanical,
-                electric: total_electric,
-                total: total_bikes,
-            },
-            available_docks: total_available_docks,
-            occupancy_rate,
-        };
-
         Ok(GetAreaStatisticsOutput {
-            area_stats: stats,
+            area_stats: AreaStatistics {
+                total_stations,
+                operational_stations,
+                total_capacity,
+                available_bikes: AvailableBikesStats {
+                    mechanical: total_mechanical,
+                    electric: total_electric,
+                    total: total_bikes,
+                },
+                available_docks: total_available_docks,
+                occupancy_rate,
+            },
             bounds: input.bounds,
         })
     }
@@ -279,39 +265,14 @@ impl McpToolHandler {
         &self,
         input: PlanBikeJourneyInput,
     ) -> Result<PlanBikeJourneyOutput> {
-        if !input.origin.is_valid_paris_metro() {
-            return Err(Error::InvalidCoordinates {
-                latitude: input.origin.latitude,
-                longitude: input.origin.longitude,
-            });
-        }
+        Self::validate_paris_coordinates(&input.origin)?;
+        Self::validate_paris_coordinates(&input.destination)?;
 
-        if !input.destination.is_valid_paris_metro() {
-            return Err(Error::InvalidCoordinates {
-                latitude: input.destination.latitude,
-                longitude: input.destination.longitude,
-            });
-        }
-
-        // Enforce 50km distance limit from Paris City Hall for both origin and destination
-        if !input.origin.is_within_paris_service_area() {
-            let distance_km = input.origin.distance_to(&PARIS_CITY_HALL) / 1000.0;
-            return Err(Error::OutsideServiceArea { distance_km });
-        }
-
-        if !input.destination.is_within_paris_service_area() {
-            let distance_km = input.destination.distance_to(&PARIS_CITY_HALL) / 1000.0;
-            return Err(Error::OutsideServiceArea { distance_km });
-        }
-
-        // Find nearby stations for pickup and dropoff using live data
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        // Get preferences or use defaults
         let preferences = input.preferences.unwrap_or_default();
 
-        // Find pickup stations near origin
         let mut pickup_candidates: Vec<StationWithDistance> = all_stations
             .iter()
             .filter_map(|station| {
@@ -334,7 +295,6 @@ impl McpToolHandler {
         pickup_candidates.sort_by_key(|s| s.straight_line_distance_meters);
         pickup_candidates.truncate(3);
 
-        // Find dropoff stations near destination
         let mut dropoff_candidates: Vec<StationWithDistance> = all_stations
             .iter()
             .filter_map(|station| {
@@ -346,7 +306,6 @@ impl McpToolHandler {
                 if distance <= preferences.max_walk_distance
                     && station.is_operational()
                     && station.has_available_docks(1)
-                // At least 1 dock available
                 {
                     Some(StationWithDistance {
                         station: station.clone(),
@@ -361,18 +320,12 @@ impl McpToolHandler {
         dropoff_candidates.sort_by_key(|s| s.straight_line_distance_meters);
         dropoff_candidates.truncate(3);
 
-        let pickup_stations = pickup_candidates;
-        let dropoff_stations = dropoff_candidates;
-
-        // Generate journey recommendations
         let mut recommendations = Vec::new();
 
-        if !pickup_stations.is_empty() && !dropoff_stations.is_empty() {
-            // Create recommendations by pairing closest pickup with closest dropoff
-            let best_pickup = &pickup_stations[0];
-            let best_dropoff = &dropoff_stations[0];
+        if !pickup_candidates.is_empty() && !dropoff_candidates.is_empty() {
+            let best_pickup = &pickup_candidates[0];
+            let best_dropoff = &dropoff_candidates[0];
 
-            // Calculate confidence score based on walking distances
             let max_walk = f64::from(preferences.max_walk_distance);
             let pickup_walk_ratio = f64::from(best_pickup.straight_line_distance_meters) / max_walk;
             let dropoff_walk_ratio =
@@ -390,8 +343,8 @@ impl McpToolHandler {
 
         Ok(PlanBikeJourneyOutput {
             journey: BikeJourney {
-                pickup_stations,
-                dropoff_stations,
+                pickup_stations: pickup_candidates,
+                dropoff_stations: dropoff_candidates,
                 recommendations,
             },
         })
@@ -435,7 +388,6 @@ impl McpToolHandler {
     /// Test connectivity to data sources for health checks
     pub async fn test_connectivity(&self) -> Result<()> {
         let mut data_client = self.data_client.write().await;
-        // Simple connectivity test by fetching reference data
         data_client.get_all_stations(false).await?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Extract a generic `fetch_paginated` helper in `VelibDataClient`, removing ~40 lines of near-identical loop logic that was duplicated between `fetch_reference_stations` and `fetch_realtime_status`. Both methods now delegate their pagination to the shared helper.
- Replace the hand-rolled `ServiceCapabilities { accepts_credit_card: false, has_charging_station: false, is_virtual_station: false }` literal with `ServiceCapabilities::default()` in `parse_reference_station`.
- Simplify `parse_realtime_status`: collapse the default-time string construction into a direct `.and_then` chain on the optional `duedate` field, removing an intermediate `let`.
- Extract `McpToolHandler::validate_paris_coordinates` — a free function called by both `find_nearby_stations` and `plan_bike_journey` — to eliminate the copy-pasted bounding-box + service-area guard (4 `if` blocks down to 2 call sites).
- Fix `get_station_by_code` handler to honour `input.include_real_time` instead of unconditionally passing `true` to the data client.
- Remove several redundant intermediate bindings (`let stations = nearby_stations`, `let pickup_stations = pickup_candidates`, etc.) that added lines without adding clarity.

## Net change

`src/data/client.rs` and `src/mcp/handlers.rs`: **-88 lines** total while keeping all existing tests green (34 unit tests + integration + smoke tests).

## Test plan

- [x] `cargo check` passes
- [x] All 34 lib unit tests pass
- [x] Integration and smoke tests pass

https://claude.ai/code/session_015qvaT243enNQXYo7QXJudF