### PR TITLE
[velib-mcp] Clarity: fix incorrect CLI docs and remove redundant inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ A high-performance Model Context Protocol (MCP) server providing access to Paris
 
 ## Quick Start - Install with Claude Code
 
-Install and use the Velib MCP server with Claude Code in one command:
+Install and configure the server:
 
 ```bash
-# Install and configure the server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-claude config add-server velib-mcp "cargo run --release -- --port 3000"
+PORT=3000 velib-mcp &
+claude config add-server velib-mcp "http://localhost:3000/mcp"
 ```
+
+The server is configured via environment variables (see [Configuration](#configuration)).
 
 Then use in Claude Code:
 ```
@@ -45,6 +47,20 @@ This project exposes two key Parisian datasets through MCP:
 - `get_area_statistics`: Get aggregated statistics for a geographic area
 - `plan_bike_journey`: Plan a bike journey with pickup and dropoff suggestions
 
+## Configuration
+
+The server reads its listen address from two environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IP`     | `0.0.0.0` | IP address to bind |
+| `PORT`   | `8080`    | TCP port to listen on |
+
+Example:
+```bash
+IP=127.0.0.1 PORT=9000 velib-mcp
+```
+
 ## Integration with Other AI Tools
 
 <details>
@@ -52,23 +68,22 @@ This project exposes two key Parisian datasets through MCP:
 
 ### ChatGPT
 ```bash
-# Install server
+# Install and start the server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server on port 8080
-velib-mcp
+PORT=8080 velib-mcp
 # Configure in ChatGPT Custom Instructions or use via API
 ```
 
 ### Cursor
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Add to Cursor's settings.json
+
+Add to Cursor's `settings.json`. The server must be started separately before
+launching Cursor.
+
+```json
 {
   "mcp.servers": {
     "velib": {
-      "command": "velib-mcp",
-      "args": ["--port", "8080"]
+      "url": "http://localhost:8080/mcp"
     }
   }
 }
@@ -76,17 +91,18 @@ cargo install --git https://github.com/dominicburkart/velib-mcp.git
 
 ### Le Chat / Mistral
 ```bash
-# Install server
+# Install and start the server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server and use via API calls
-velib-mcp --port 8080
+PORT=8080 velib-mcp
+# Then point your Mistral integration at http://localhost:8080/mcp
 ```
 
 ### Windsurf
 ```bash
-# Install server
+# Install and start the server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Configure in Windsurf MCP settings
+PORT=8080 velib-mcp
+# Configure in Windsurf MCP settings pointing to http://localhost:8080/mcp
 ```
 
 </details>
@@ -116,10 +132,10 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo audit
 ```
 
-### Podman
+### Container
 
 ```bash
-# Build container image
+# Build image (uses Podman; substitute docker if preferred)
 podman build -t velib-mcp .
 
 # Run container
@@ -133,7 +149,7 @@ The project is configured for deployment to Scaleway Container Serverless via Gi
 ## Architecture
 
 - **Language**: Rust
-- **Deployment**: Scaleway Container Serverless  
+- **Deployment**: Scaleway Container Serverless
 - **CI/CD**: GitHub Actions
 - **Development**: Test-Driven Development approach
 - **Container**: Distroless Debian base image

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -14,9 +14,9 @@ use tracing::{debug, info};
 const VELIB_STATIONS_URL: &str = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-emplacement-des-stations/records";
 const VELIB_REALTIME_URL: &str = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/records";
 
-// Cache TTLs
-const REFERENCE_CACHE_TTL_MINUTES: i64 = 5; // 5 minutes for reference data
-const REALTIME_CACHE_TTL_MINUTES: i64 = 2; // 2 minutes for real-time data
+// How long to keep each dataset in the in-process cache before re-fetching
+const REFERENCE_CACHE_TTL_MINUTES: i64 = 5;
+const REALTIME_CACHE_TTL_MINUTES: i64 = 2;
 
 #[derive(Debug)]
 pub struct VelibDataClient {
@@ -80,7 +80,7 @@ impl VelibDataClient {
 
         let mut all_stations = Vec::new();
         let mut offset = 0;
-        let limit = 100; // API limit
+        let limit = 100;
 
         loop {
             let query_params = &[
@@ -99,7 +99,7 @@ impl VelibDataClient {
                 .ok_or_else(|| Error::Internal(anyhow::anyhow!("Invalid API response format")))?;
 
             if records.is_empty() {
-                break; // No more records
+                break;
             }
 
             for record in records {
@@ -110,7 +110,7 @@ impl VelibDataClient {
 
             offset += limit;
             if records.len() < limit {
-                break; // Last page
+                break;
             }
         }
 
@@ -138,7 +138,7 @@ impl VelibDataClient {
 
         let mut all_status = HashMap::new();
         let mut offset = 0;
-        let limit = 100; // API limit
+        let limit = 100;
 
         loop {
             let query_params = &[
@@ -157,7 +157,7 @@ impl VelibDataClient {
                 .ok_or_else(|| Error::Internal(anyhow::anyhow!("Invalid API response format")))?;
 
             if records.is_empty() {
-                break; // No more records
+                break;
             }
 
             for record in records {
@@ -168,7 +168,7 @@ impl VelibDataClient {
 
             offset += limit;
             if records.len() < limit {
-                break; // Last page
+                break;
             }
         }
 
@@ -238,7 +238,6 @@ impl VelibDataClient {
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing capacity")))?
             as u16;
 
-        // Parse coordinates from coordonnees_geo
         let geo_point = record["coordonnees_geo"]
             .as_object()
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing geo coordinates")))?;
@@ -251,21 +250,14 @@ impl VelibDataClient {
             .as_f64()
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing longitude")))?;
 
-        let coordinates = crate::types::Coordinates::new(latitude, longitude);
-
-        // Parse service capabilities
-        let capabilities = ServiceCapabilities {
-            accepts_credit_card: false,  // Not available in current API
-            has_charging_station: false, // Not available in current API
-            is_virtual_station: false,   // Not available in current API
-        };
-
+        // ServiceCapabilities fields are not exposed by the Paris Open Data API;
+        // the struct defaults to all-false until the API provides this information.
         Ok(StationReference {
             station_code,
             name,
-            coordinates,
+            coordinates: crate::types::Coordinates::new(latitude, longitude),
             capacity,
-            capabilities,
+            capabilities: ServiceCapabilities::default(),
         })
     }
 
@@ -277,12 +269,9 @@ impl VelibDataClient {
             .to_string();
 
         let mechanical_bikes = record["mechanical"].as_u64().unwrap_or(0) as u16;
-
         let electric_bikes = record["ebike"].as_u64().unwrap_or(0) as u16;
-
         let available_docks = record["numdocksavailable"].as_u64().unwrap_or(0) as u16;
 
-        // Parse status
         let status_str = record["is_installed"].as_str().unwrap_or("NON");
 
         let status = match status_str {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -83,25 +83,21 @@ impl McpToolHandler {
             return Err(Error::OutsideServiceArea { distance_km });
         }
 
-        // Fetch live station data
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        // Filter stations by distance and bike type
         let mut nearby_stations: Vec<StationWithDistance> = all_stations
             .into_iter()
             .filter_map(|station| {
                 let distance = query_point.distance_to(&station.reference.coordinates) as u32;
 
-                // Check if within search radius
                 if distance <= input.radius_meters {
-                    // Check if station has the requested bike type (if specified)
                     let has_requested_bikes = match &input.availability_filter {
                         Some(filter) => match &filter.bike_type {
                             Some(bike_type) => station.has_available_bikes(bike_type),
                             None => true,
                         },
-                        None => true, // No filter specified
+                        None => true,
                     };
 
                     if has_requested_bikes && station.is_operational() {
@@ -118,10 +114,7 @@ impl McpToolHandler {
             })
             .collect();
 
-        // Sort by distance
         nearby_stations.sort_by_key(|s| s.straight_line_distance_meters);
-
-        // Limit results
         nearby_stations.truncate(input.limit as usize);
 
         let stations = nearby_stations;
@@ -171,7 +164,6 @@ impl McpToolHandler {
             });
         }
 
-        // Fetch live station data and search by name
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
@@ -193,10 +185,7 @@ impl McpToolHandler {
             })
             .collect();
 
-        // Sort by name for consistent results
         matching_stations.sort_by(|a, b| a.reference.name.cmp(&b.reference.name));
-
-        // Limit results
         matching_stations.truncate(input.limit as usize);
 
         let stations = matching_stations;
@@ -221,13 +210,11 @@ impl McpToolHandler {
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        // Filter stations within the specified bounds
         let area_stations: Vec<&VelibStation> = all_stations
             .iter()
             .filter(|station| input.bounds.contains(&station.reference.coordinates))
             .collect();
 
-        // Calculate area statistics from live data
         let total_stations = area_stations.len() as u32;
         let operational_stations = area_stations
             .iter()
@@ -293,7 +280,6 @@ impl McpToolHandler {
             });
         }
 
-        // Enforce 50km distance limit from Paris City Hall for both origin and destination
         if !input.origin.is_within_paris_service_area() {
             let distance_km = input.origin.distance_to(&PARIS_CITY_HALL) / 1000.0;
             return Err(Error::OutsideServiceArea { distance_km });
@@ -304,14 +290,11 @@ impl McpToolHandler {
             return Err(Error::OutsideServiceArea { distance_km });
         }
 
-        // Find nearby stations for pickup and dropoff using live data
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        // Get preferences or use defaults
         let preferences = input.preferences.unwrap_or_default();
 
-        // Find pickup stations near origin
         let mut pickup_candidates: Vec<StationWithDistance> = all_stations
             .iter()
             .filter_map(|station| {
@@ -346,7 +329,6 @@ impl McpToolHandler {
                 if distance <= preferences.max_walk_distance
                     && station.is_operational()
                     && station.has_available_docks(1)
-                // At least 1 dock available
                 {
                     Some(StationWithDistance {
                         station: station.clone(),


### PR DESCRIPTION
## Summary

### README — incorrect CLI flags (high impact)

Every integration example in the README told users to run `velib-mcp --port 8080` or `cargo run --release -- --port 3000`. The binary accepts **no CLI flags** — the listen address is configured exclusively via `IP` and `PORT` environment variables. These examples would silently fail or start on the wrong port.

Changes:
- Quick Start corrected to `PORT=3000 velib-mcp &`
- New **Configuration** table documents `IP` and `PORT` in one place
- All four integration snippets (ChatGPT, Cursor, Le Chat, Windsurf) corrected to `PORT=8080 velib-mcp`
- Cursor `settings.json` replaced the wrong `args: ["--port", "8080"]` pattern with the correct `url` field pointing at the running server
- "Podman" section renamed to "Container" with a note that Docker is a drop-in alternative

### Source — noisy inline comments removed

Comments that restate what adjacent code already expresses were removed. Specific removals:

- `// 5 minutes for reference data` / `// 2 minutes for real-time data` after TTL constants (names are self-documenting)
- Three `// Not available in current API` field comments collapsed into one sentence on `ServiceCapabilities::default()`
- `// No more records`, `// Last page`, `// API limit` in pagination loops
- `// No filter specified`, `// At least 1 dock available` trailing comments
- Section-heading comments (`// Fetch live station data`, `// Filter stations…`, `// Sort by name…`, `// Calculate area statistics…`, `// Get preferences or use defaults`, `// Find pickup stations near origin`) inside short handler methods that need no internal navigation aids

## Test plan

- [x] `cargo check` passes
- [x] All 34 lib unit tests pass

https://claude.ai/code/session_015qvaT243enNQXYo7QXJudF