### PR TITLE
feat(ci): add all-checks job with self-validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,38 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --release
+
+  all-checks:
+    name: All Checks Passed
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - test
+      - fmt
+      - clippy
+      - security
+      - feature-testing
+      - build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify gate covers every job
+        run: |
+          set -euo pipefail
+          all_jobs=$(yq -r '.jobs | keys | .[]' .github/workflows/ci.yml | sort)
+          gate_needs=$(yq -r '.jobs["all-checks"].needs | .[]' .github/workflows/ci.yml | sort)
+          expected=$(echo "$all_jobs" | grep -vx 'all-checks')
+          missing=$(comm -23 <(echo "$expected") <(echo "$gate_needs") || true)
+          if [ -n "$missing" ]; then
+            echo "::error::Jobs missing from 'all-checks'.needs:"
+            echo "$missing"
+            echo "Add them to .github/workflows/ci.yml under jobs.all-checks.needs"
+            exit 1
+          fi
+          echo "OK: all $(echo "$expected" | wc -l | tr -d ' ') non-gate jobs covered"
+
+      - name: Fail if any dependency failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more CI jobs failed or were cancelled"
+          exit 1


### PR DESCRIPTION
## Summary
- Adds an all-checks gate job to ci.yml that only passes if all other CI jobs pass
- Includes yq-based self-validation: if someone adds a new job to ci.yml without listing it in all-checks.needs, the gate will fail

## Test plan
- [ ] CI runs and the new all-checks job passes
- [ ] Self-validation step correctly identifies all existing jobs