### PR TITLE
docs: clarity pass — remove bloat, fix stale content, align schemas with code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,227 +1,65 @@
-# Projet CLAUDE : Serveur MCP Velib
+# CLAUDE.md — Velib MCP Server
 
-## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP.
+Rust expert working on an open-source MCP server that exposes Paris Vélib bike-sharing data to AI assistants.
 
-- **Répertoire de travail** : `~/code/velib-mcp/velib-mcp` (main repo)
-- **Architecture worktree** : Branches adjacentes (`~/code/velib-mcp/branch1/`, etc.)
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
+## Project Goal
 
-### Structure du Projet
+Expose two Paris Open Data datasets through the Model Context Protocol (MCP):
+
+- **Real-time availability**: <https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/>
+- **Station locations**: <https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/>
+
+## Key Files
+
+| Path | Purpose |
+|------|---------|
+| `src/main.rs` | Entry point |
+| `src/lib.rs` | Public API surface |
+| `src/types.rs` | Core data types |
+| `src/error.rs` | Error types and MCP error codes |
+| `src/data/` | HTTP client and cache |
+| `src/mcp/` | MCP protocol implementation |
+| `src/server/` | Axum HTTP server |
+| `docs/api/data_analysis.md` | Vélib dataset field reference |
+| `docs/api/mcp_interface_spec.md` | MCP tool/resource specifications |
+| `docs/api/mcp_schemas.md` | Data schema reference (see `src/types.rs` for authoritative definitions) |
+
+## Development Commands
+
+```bash
+cargo test                                        # run all tests
+cargo fmt                                         # format code
+cargo clippy --all-targets --all-features -- -D warnings  # lint
+cargo audit                                       # security audit
+```
+
+## Architecture
+
+- **Language**: Rust (latest stable)
+- **Server**: Axum over HTTP/WebSocket
+- **Deployment**: Scaleway Container Serverless via GitHub Actions on `main`
+- **Container**: Podman, Debian distroless base
+- **Approach**: TDD — write failing tests first
+
+## Worktrees
+
+Branch worktrees live adjacent to the main repo:
+
 ```
 ~/code/velib-mcp/
-├── velib-mcp/              # Dépôt principal (ce répertoire)
-│   ├── CLAUDE.md           # Configuration Claude partagée
-│   ├── src/                # Code source
-│   ├── docs/               # Documentation
-│   └── ...                 # Fichiers du projet
-├── branch1/                # Worktree pour branche feature
-│   ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-│   └── ...                 # Fichiers spécifiques à la branche
-└── branch2/                # Autre worktree
-    ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-    └── ...                 # Fichiers spécifiques à la branche
+├── velib-mcp/     # main repo
+├── branch1/       # feature worktree
+└── branch2/       # another worktree
 ```
 
-**Important** : Ce fichier CLAUDE.md est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
-
-## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
-
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
-
-- **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
-
-## État Actuel du Projet
-
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
-
-### Architecture Technique
-- **Serveur MCP Rust** pour données Velib Paris
-- **Deux datasets principaux** :
-  - Disponibilité stations en temps réel
-  - Localisations et métadonnées des stations
-- **Déploiement Scaleway** via GitHub Actions
-- **Suite de tests complète** (18+ tests)
-- **Validations sécurité** incluant limites zone service 50km
-
-### Fichiers Importants
-- `/src/main.rs` - Point d'entrée principal
-- `/src/mcp/` - Implémentation protocole MCP
-- `/src/data/` - Client données et cache
-- `/src/types.rs` - Structures de données principales
-- `/docs/api/data_analysis.md` - Analyse données complète
-- `/docs/context/etat_actuel.md` - Suivi statut projet
-
-### Commandes Développement
 ```bash
-cargo test                     # Tests complets
-cargo fmt                      # Formatage code
-cargo clippy                   # Analyse statique
-cargo audit                    # Audit sécurité
-```
-
-### Déploiement
-- **Cible** : Scaleway Container Serverless
-- **Déclencheur** : Push vers branche main
-- **Registry** : Scaleway Container Registry
-- **Build** : Containerisation Podman
-
-### Gestion Worktrees
-```bash
-# Créer nouveau worktree
+# Create
 git worktree add ../branch-name branch-name
-cd ../branch-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
 
-# Supprimer worktree
-git worktree remove ../branch-name
-git worktree prune
+# Remove
+git worktree remove ../branch-name && git worktree prune
 ```
 
-## Processus de Développement Multi-Agents
+## Deployment
 
-### Architecture Optimisée pour Performance, Qualité et Autonomie
-
-Ce processus transforme l'approche linéaire traditionnelle en 5 phases parallèles pour maximiser l'efficacité d'équipe.
-
-#### Phase 1: Analyse Concurrente (PM + Test Designer)
-**Durée**: ~30 min | **Parallélisation**: PM et Test Designer travaillent simultanément
-
-**Product Manager (Rôle: Extraction de Valeur)**
-- Analyse issue GitHub avec template structuré
-- Extraction valeur métier claire et actionnable
-- Validation exigences avec dev-utilisateur
-- Production: Spécification fonctionnelle validée
-
-**Test Designer (Rôle: Planification Technique)**
-- Analyse technique parallèle de l'issue
-- Estimation nombre features/refactors uniques
-- Planification PRs et worktrees nécessaires
-- Production: Plan d'implémentation détaillé
-
-#### Phase 2: Fondation Tests (Test Designer)
-**Durée**: ~45 min | **Focus**: Environnement + Spécifications Test
-
-**Préparation Environnement**
-```bash
-# Création worktree optimisée avec template
-git worktree add ../feature-name feature/branch-name
-cd ../feature-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
-cargo test --no-run  # Pré-compilation dependencies
-```
-
-**Implémentation Tests TDD**
-- Tests d'intégration définissant comportement attendu
-- Tests unitaires pour composants critiques
-- Tests fuzz si applicable (données externes)
-- Validation: Tests échouent de manière attendue
-
-#### Phase 3: Sprint Implémentation (Ingénieur)
-**Durée**: Variable | **Focus**: Développement avec Validation Continue
-
-**Workflow Micro-Commits**
-```bash
-# Cycle développement optimisé
-while [[ $tests_failing ]]; do
-    # Implémentation incrémentale
-    cargo clippy --fix
-    cargo fmt
-    cargo test
-    git add -A && git commit -m "feat: micro-increment"
-done
-```
-
-**Intégration Continue Locale**
-- Validation automatique à chaque commit
-- Feedback temps réel des tests
-- Métriques qualité code continues
-- Résolution bloquants technique immédiate
-
-#### Phase 4: Révision Parallèle (Ingénieur + Réviseur)
-**Durée**: ~20 min | **Parallélisation**: Préparation + Analyse simultanées
-
-**Ingénieur (Préparation PR)**
-- Organisation commits en histoire cohérente
-- Rédaction description PR succincte
-- Validation finale checks locaux
-- Ouverture PR avec lien issue origine
-
-**Réviseur Senior (Analyse Qualité)**
-- Évaluation architecture et patterns Rust
-- Vérification couverture tests vs objectifs PM
-- Analyse lisibilité et extensibilité code
-- Validation sécurité et ergonomie
-
-**Boucle Feedback Structurée**
-- Critères évaluation standardisés
-- Dialogue constructif jusqu'accord
-- Résolution collaborative des points bloquants
-
-#### Phase 5: Intégration Automatisée (Ops)
-**Durée**: ~10 min | **Focus**: Déploiement et Validation
-
-**Merge et CI/CD**
-- Merge automatique post-approbation
-- Validation CI complète sur main
-- Monitoring santé déploiement
-- Métriques performance production
-
-### Templates et Checklists
-
-#### Template Analyse Issue (PM)
-```markdown
-## Valeur Métier
-- [ ] Problème utilisateur identifié
-- [ ] Solution proposée claire
-- [ ] Critères succès mesurables
-- [ ] Validation dev-utilisateur
-
-## Exigences Techniques
-- [ ] Contraintes techniques identifiées
-- [ ] Impact architecture évalué
-- [ ] Effort estimé (S/M/L/XL)
-```
-
-#### Checklist Qualité (Réviseur)
-```markdown
-## Architecture & Design
-- [ ] Patterns Rust idiomatiques respectés
-- [ ] Séparation responsabilités claire
-- [ ] Gestion erreurs appropriée
-- [ ] Performance optimisée
-
-## Tests & Couverture
-- [ ] Tests couvrent objectifs PM
-- [ ] Edge cases identifiés et testés
-- [ ] Intégration validée
-- [ ] Documentation à jour
-```
-
-### Métriques de Performance
-
-**Gains Attendus vs Processus Linéaire**
-- **Temps cycle**: -40% (parallélisation phases)
-- **Temps attente**: -60% (élimination handoffs)
-- **Qualité code**: +25% (validation continue)
-- **Autonomie équipe**: +50% (rôles auto-suffisants)
-
-### Intégration Architecture Existante
-
-Ce processus s'intègre parfaitement avec:
-- Architecture worktree existante (isolation parallèle)
-- CI/CD GitHub Actions (validation automatisée)
-- Hooks pre-commit (qualité continue)
-- Toolchain Rust standard (fmt, clippy, audit)
+Triggered automatically on push to `main`. Uses `deploy_to_scaleway.sh` and the env vars in `.env.deploy.example`.

--- a/README.md
+++ b/README.md
@@ -1,147 +1,94 @@
 # Velib MCP Server
 
-[![Test Coverage](https://img.shields.io/badge/coverage-check%20actions-brightgreen)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml)
 [![Tests](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml)
-[![Security Audit](https://img.shields.io/badge/security-audit%20passing-brightgreen)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/velib-mcp#license)
-[![Rust Version](https://img.shields.io/badge/rust-latest%20stable-orange)](https://www.rust-lang.org/)
 [![Deploy Status](https://github.com/DominicBurkart/velib-mcp/actions/workflows/deploy.yml/badge.svg)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/deploy.yml)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/velib-mcp#license)
 
-A high-performance Model Context Protocol (MCP) server providing access to Paris Velib bike sharing data for AI assistants.
+A Rust MCP server providing real-time Paris Vélib bike-sharing data to AI assistants.
 
-## Quick Start - Install with Claude Code
+## Data Sources
 
-Install and use the Velib MCP server with Claude Code in one command:
+- [Real-time availability](https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/)
+- [Station locations](https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/)
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `find_nearby_stations` | Stations within a radius of given coordinates |
+| `get_station_by_code` | Full details for a specific station |
+| `search_stations_by_name` | Name search with optional fuzzy matching |
+| `get_area_statistics` | Aggregated stats for a bounding box |
+| `plan_bike_journey` | Pickup/dropoff station suggestions for a journey |
+
+See [`docs/api/mcp_interface_spec.md`](docs/api/mcp_interface_spec.md) for full input/output schemas.
+
+## Quick Start
 
 ```bash
-# Install and configure the server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-claude config add-server velib-mcp "cargo run --release -- --port 3000"
 ```
 
-Then use in Claude Code:
+### Claude Code
+
+```bash
+claude config add-server velib-mcp "velib-mcp"
+```
+
+Example prompts:
 ```
 @velib find nearby stations at latitude 48.8566 longitude 2.3522
 @velib get station by code 16107
 @velib search stations by name "châtelet"
 ```
 
-## Overview
-
-This project exposes two key Parisian datasets through MCP:
-- **Real-time availability**: Current bike and dock availability at stations
-- **Station locations**: Geographic information and details about all Velib stations
-
-## Data Sources
-
-- [Velib Real-time Availability](https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/)
-- [Velib Station Locations](https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/)
-
-## Available Tools
-
-- `find_nearby_stations`: Find Velib stations within a radius of coordinates
-- `get_station_by_code`: Get detailed information about a specific station
-- `search_stations_by_name`: Search stations by name with optional fuzzy matching
-- `get_area_statistics`: Get aggregated statistics for a geographic area
-- `plan_bike_journey`: Plan a bike journey with pickup and dropoff suggestions
-
-## Integration with Other AI Tools
-
-<details>
-<summary>Click to expand integration guides</summary>
-
-### ChatGPT
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server on port 8080
-velib-mcp
-# Configure in ChatGPT Custom Instructions or use via API
-```
-
 ### Cursor
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Add to Cursor's settings.json
+
+Add to `settings.json`:
+```json
 {
   "mcp.servers": {
     "velib": {
-      "command": "velib-mcp",
-      "args": ["--port", "8080"]
+      "command": "velib-mcp"
     }
   }
 }
 ```
 
-### Le Chat / Mistral
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server and use via API calls
-velib-mcp --port 8080
-```
+### Other MCP-compatible clients
 
-### Windsurf
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Configure in Windsurf MCP settings
-```
-
-</details>
+Run `velib-mcp` (listens on `$IP:$PORT`, defaulting to `0.0.0.0:8080`) and point your client at it over HTTP/WebSocket (JSON-RPC 2.0).
 
 ## Development
 
-### Prerequisites
-
-- Rust (latest stable)
-- OpenSSL development libraries
-- pkg-config
-
-### Setup
+**Prerequisites**: Rust (stable), OpenSSL dev libraries, pkg-config
 
 ```bash
 git clone https://github.com/dominicburkart/velib-mcp.git
 cd velib-mcp
 cargo build
-```
-
-### Testing
-
-```bash
 cargo test
-cargo fmt --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo audit
 ```
 
 ### Podman
 
 ```bash
-# Build container image
 podman build -t velib-mcp .
-
-# Run container
 podman run -p 8080:8080 velib-mcp
 ```
 
 ## Deployment
 
-The project is configured for deployment to Scaleway Container Serverless via GitHub Actions on pushes to the main branch.
+Push to `main` triggers automatic deployment to Scaleway Container Serverless via GitHub Actions. See `.env.deploy.example` for required environment variables.
 
 ## Architecture
 
 - **Language**: Rust
-- **Deployment**: Scaleway Container Serverless  
+- **Deployment**: Scaleway Container Serverless
 - **CI/CD**: GitHub Actions
-- **Development**: Test-Driven Development approach
-- **Container**: Distroless Debian base image
+- **Container**: Distroless Debian
+- **Approach**: Test-Driven Development
 
 ## License
 
-Licensed under either of:
-- Apache License, Version 2.0
-- MIT License
-
-at your option.
+Licensed under either of Apache License 2.0 or MIT License, at your option.

--- a/docs/api/mcp_schemas.md
+++ b/docs/api/mcp_schemas.md
@@ -1,361 +1,157 @@
-# Schémas de Données MCP - Velib Server
+# MCP Data Schemas — Velib Server
 
-## Vue d'ensemble
+> **Note**: These schemas are reference documentation. The authoritative Rust definitions live in [`src/types.rs`](../../src/types.rs). When the two diverge, the source code is correct.
 
-Ce document définit les schémas de données formels pour l'exposition des données Velib via le protocole MCP (Model Context Protocol).
+## Core Types
 
-## Types de Base
-
-### Coordonnées Géographiques
+### Coordinates
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Coordinates {
-    /// Latitude en degrés décimaux
     pub latitude: f64,
-    /// Longitude en degrés décimaux  
     pub longitude: f64,
 }
 ```
 
-### État de Station
+### StationStatus
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum StationStatus {
-    /// Station opérationnelle
-    Operational,
-    /// Station installée mais non opérationnelle
-    Installed,
-    /// Station en maintenance
-    Maintenance,
-    /// Station hors service
-    OutOfService,
+    Open,        // renting and returning enabled
+    Closed,      // not operational
+    Maintenance, // temporarily unavailable
 }
 ```
 
-### Capacités de Service
+### ServiceCapabilities
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ServiceCapabilities {
-    /// Location de vélos autorisée
-    pub renting_enabled: bool,
-    /// Retour de vélos autorisé
-    pub returning_enabled: bool,
-    /// Station installée et accessible
-    pub installed: bool,
+    pub accepts_credit_card: bool,
+    pub has_charging_station: bool,
+    pub is_virtual_station: bool,
 }
 ```
 
-## Schémas Principaux
-
-### Station de Référence
+### BikeAvailability
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct StationReference {
-    /// Identifiant unique de la station
-    pub station_code: String,
-    
-    /// Nom descriptif de la station
-    pub name: String,
-    
-    /// Coordonnées géographiques précises
-    pub coordinates: Coordinates,
-    
-    /// Capacité totale de la station
-    pub capacity: u16,
-    
-    /// Commune ou arrondissement
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub commune: Option<String>,
-    
-    /// Code INSEE de la commune
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub insee_code: Option<String>,
-}
-```
-
-### Disponibilité Temps Réel
-```rust
-use chrono::{DateTime, Utc};
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BikeAvailability {
-    /// Vélos mécaniques disponibles
     pub mechanical: u16,
-    
-    /// Vélos électriques disponibles
     pub electric: u16,
-}
-
-impl BikeAvailability {
-    /// Total de vélos disponibles
-    pub fn total(&self) -> u16 {
-        self.mechanical + self.electric
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct RealTimeStatus {
-    /// Référence à la station
-    pub station_code: String,
-    
-    /// Vélos disponibles par type
-    pub bikes: BikeAvailability,
-    
-    /// Emplacements libres pour retour
-    pub available_docks: u16,
-    
-    /// Capacités de service actuelles
-    pub service: ServiceCapabilities,
-    
-    /// État général de la station
-    pub status: StationStatus,
-    
-    /// Horodatage de dernière mise à jour
-    pub last_updated: DateTime<Utc>,
-    
-    /// Horodatage de validité des données
-    pub valid_until: DateTime<Utc>,
+    // .total() returns mechanical + electric (saturating)
 }
 ```
 
-### Station Complète (Vue Consolidée)
+### DataFreshness
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct VelibStation {
-    /// Données de référence de la station
-    #[serde(flatten)]
-    pub reference: StationReference,
-    
-    /// État temps réel actuel
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub real_time: Option<RealTimeStatus>,
-    
-    /// Indicateur de fraîcheur des données
-    pub data_freshness: DataFreshness,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DataFreshness {
-    /// Données très récentes (< 2 minutes)
-    Fresh,
-    /// Données acceptables (< 5 minutes)
-    Acceptable,
-    /// Données anciennes (> 5 minutes)
-    Stale,
-    /// Données indisponibles
-    Unavailable,
+    Fresh,     // < 10 minutes old
+    Recent,    // 10–30 minutes old
+    Stale,     // 30–120 minutes old
+    VeryStale, // > 120 minutes old
 }
 ```
 
-## Schémas de Requête MCP
+## Main Structs
 
-### Paramètres de Recherche Géographique
+### StationReference
 ```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StationReference {
+    pub station_code: String,
+    pub name: String,
+    pub coordinates: Coordinates,
+    pub capacity: u16,          // validated: 1–200
+    pub capabilities: ServiceCapabilities,
+}
+```
+
+### RealTimeStatus
+```rust
+pub struct RealTimeStatus {
+    pub bikes: BikeAvailability,
+    pub available_docks: u16,
+    pub status: StationStatus,
+    pub last_update: DateTime<Utc>,
+    pub data_freshness: DataFreshness,  // computed from last_update age
+}
+```
+
+### VelibStation (consolidated view)
+```rust
+pub struct VelibStation {
+    pub reference: StationReference,
+    pub real_time: Option<RealTimeStatus>,
+}
+```
+
+Validation rule: `bikes.total() + available_docks <= capacity`.
+
+## Query Types
+
+### GeographicQuery
+```rust
 pub struct GeographicQuery {
-    /// Point central de recherche
     pub center: Coordinates,
-    
-    /// Rayon de recherche en mètres
     pub radius_meters: u32,
-    
-    /// Nombre maximum de résultats
-    #[serde(default = "default_limit")]
-    pub limit: u16,
+    pub limit: u16,  // default 50
 }
-
-fn default_limit() -> u16 { 50 }
 ```
 
-### Filtres de Disponibilité
+Service area constraint: coordinates must be within 50 km of Paris City Hall (48.8565°N, 2.3514°E).
+
+### AvailabilityFilter
 ```rust
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct AvailabilityFilter {
-    /// Minimum de vélos disponibles requis
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_bikes: Option<u16>,
-    
-    /// Minimum d'emplacements libres requis
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_docks: Option<u16>,
-    
-    /// Type de vélos requis
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bike_type: Option<BikeTypeFilter>,
-    
-    /// Exclure les stations hors service
-    #[serde(default = "default_true")]
-    pub exclude_out_of_service: bool,
+    pub exclude_out_of_service: bool,  // default true
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum BikeTypeFilter {
-    /// Au moins un vélo mécanique
-    MechanicalRequired,
-    /// Au moins un vélo électrique
-    ElectricRequired,
-    /// Vélos mécaniques ET électriques
-    BothRequired,
-    /// Vélos mécaniques OU électriques
-    AnyType,
-}
-
-fn default_true() -> bool { true }
-```
-
-### Requête Complète
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct StationQuery {
-    /// Contraintes géographiques
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub geographic: Option<GeographicQuery>,
-    
-    /// Filtres de disponibilité
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub availability: Option<AvailabilityFilter>,
-    
-    /// Codes de stations spécifiques
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub station_codes: Option<Vec<String>>,
-    
-    /// Inclure les données temps réel
-    #[serde(default = "default_true")]
-    pub include_real_time: bool,
+    MechanicalOnly,
+    ElectricOnly,
+    AnyType,  // default
 }
 ```
 
-## Schémas de Réponse MCP
+## Response Types
 
-### Réponse de Liste de Stations
+### StationListResponse
 ```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StationListResponse {
-    /// Stations correspondant aux critères
     pub stations: Vec<VelibStation>,
-    
-    /// Nombre total de stations trouvées
     pub total_count: usize,
-    
-    /// Pagination si applicable
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pagination: Option<PaginationInfo>,
-    
-    /// Métadonnées de la requête
     pub metadata: ResponseMetadata,
 }
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct PaginationInfo {
-    pub offset: usize,
-    pub limit: usize,
-    pub has_more: bool,
-}
 ```
 
-### Métadonnées de Réponse
+### DataSource
 ```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ResponseMetadata {
-    /// Horodatage de la réponse
-    pub response_time: DateTime<Utc>,
-    
-    /// Durée de traitement en millisecondes
-    pub processing_time_ms: u64,
-    
-    /// Source des données temps réel
-    pub real_time_source: DataSource,
-    
-    /// Source des données de référence
-    pub reference_source: DataSource,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DataSource {
-    /// Données fraîches de l'API
-    Live,
-    /// Données du cache local
-    Cached { age_seconds: u64 },
-    /// Données de sauvegarde
-    Fallback,
-    /// Données indisponibles
-    Unavailable,
+    ParisOpenData,              // fresh from API
+    Cache,                      // served from local cache
+    Fallback,                   // backup data
 }
 ```
 
-## Validation et Contraintes
+## JSON Example
 
-### Contraintes de Cohérence
-```rust
-impl VelibStation {
-    /// Valide la cohérence des données de la station
-    pub fn validate(&self) -> Result<(), ValidationError> {
-        // Vérifier la cohérence des compteurs
-        if let Some(rt) = &self.real_time {
-            let total_bikes = rt.bikes.total();
-            let expected_docks = self.reference.capacity
-                .checked_sub(total_bikes)
-                .ok_or(ValidationError::CapacityOverflow)?;
-                
-            if rt.available_docks != expected_docks {
-                return Err(ValidationError::DockCountMismatch);
-            }
-        }
-        
-        // Validation des coordonnées (Paris métropole)
-        let coords = &self.reference.coordinates;
-        if coords.latitude < 48.7 || coords.latitude > 49.0 ||
-           coords.longitude < 2.0 || coords.longitude > 2.6 {
-            return Err(ValidationError::InvalidCoordinates);
-        }
-        
-        Ok(())
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ValidationError {
-    #[error("La capacité de la station est dépassée")]
-    CapacityOverflow,
-    
-    #[error("Incohérence entre vélos et emplacements disponibles")]
-    DockCountMismatch,
-    
-    #[error("Coordonnées hors de la zone de service")]
-    InvalidCoordinates,
-}
-```
-
-## Sérialisation JSON
-
-### Exemple de Station Complète
 ```json
 {
   "station_code": "32017",
   "name": "Rouget de L'isle - Watteau",
-  "coordinates": {
-    "latitude": 48.936268,
-    "longitude": 2.358866
-  },
+  "coordinates": { "latitude": 48.936268, "longitude": 2.358866 },
   "capacity": 22,
-  "commune": "Issy-les-Moulineaux",
-  "insee_code": "92040",
-  "real_time": {
-    "station_code": "32017",
-    "bikes": {
-      "mechanical": 8,
-      "electric": 4
-    },
-    "available_docks": 10,
-    "service": {
-      "renting_enabled": true,
-      "returning_enabled": true,
-      "installed": true
-    },
-    "status": "Operational",
-    "last_updated": "2025-06-14T19:31:22Z",
-    "valid_until": "2025-06-14T19:33:22Z"
+  "capabilities": {
+    "accepts_credit_card": false,
+    "has_charging_station": false,
+    "is_virtual_station": false
   },
-  "data_freshness": "Fresh"
+  "real_time": {
+    "bikes": { "mechanical": 8, "electric": 4 },
+    "available_docks": 10,
+    "status": "OPEN",
+    "last_update": "<ISO-8601 timestamp>",
+    "data_freshness": "Fresh"
+  }
 }
 ```

--- a/docs/context/etat_actuel.md
+++ b/docs/context/etat_actuel.md
@@ -1,41 +1,29 @@
-# État Actuel du Projet Velib MCP
+# Project Status
 
-## Phase Actuelle: Phase 2 - Architecture Système
+This file tracks high-level milestone completion. For authoritative source of truth, see the code and CI results.
 
-### Statut: Prêt à commencer
-Date de dernière mise à jour: 2025-06-14
+## Completed Phases
 
-## Phase 0 - Configuration (TERMINÉE ✅)
-- ✅ Initialisation du projet Rust avec cargo
-- ✅ Configuration git et remote GitHub (DominicBurkart/velib-mcp)
-- ✅ Structure de documentation créée (/docs)
-- ✅ Configuration des hooks pre-commit (fmt, clippy, audit)
-- ✅ Workflow CI/CD GitHub Actions configuré
-- ✅ Dockerfile créé pour déploiement Scaleway (compatible Podman)
-- ✅ Système de suivi de contexte Claude initialisé
-- ✅ Documentation projet et README créés
+| Phase | Description | Status |
+|-------|-------------|--------|
+| 0 | Project setup: Rust scaffold, CI/CD, pre-commit hooks, Dockerfile | Done |
+| 1 | Data analysis: both Vélib datasets documented, Rust schemas, MCP spec with 5 tools | Done |
+| 2A | Environment setup, base server foundation | Done |
+| 2B | MCP protocol foundation and core types | Done |
+| 3A | Live API integration and data client | Done |
+| 3B | Full MCP handlers with live data | Done |
+| 4 | Repository cleanup (remove committed worktrees) | Done |
 
-## Phase 1 - Analyse des Données (TERMINÉE ✅)
-- ✅ Analyse complète du dataset disponibilité temps réel
-- ✅ Analyse complète du dataset emplacements des stations
-- ✅ Identification structure données et colonnes (15+ champs)
-- ✅ Documentation technique détaillée (/docs/api/data_analysis.md)
-- ✅ Schémas de données Rust complets (/docs/api/mcp_schemas.md)
-- ✅ Spécification interfaces MCP avec 5 tools (/docs/api/mcp_interface_spec.md)
+## Technical Stack
 
-## Prochaines Étapes (Phase 2)
-1. 🎯 Architecturer le système et composants
-2. 🎯 Définir l'organisation modulaire du code Rust
-3. 🎯 Planifier l'approche agile avec PRs cohérentes
-4. 🎯 Documenter l'architecture dans /docs/decisions
+- **Language**: Rust (stable)
+- **Deployment**: Scaleway Container Serverless
+- **CI/CD**: GitHub Actions
+- **Container**: Podman / Debian distroless
+- **Approach**: TDD
 
-## Dépendances Techniques
-- Rust (version stable récente)
-- GitHub Actions pour CI/CD
-- Scaleway CLI pour déploiement
-- Podman pour conteneurisation
+## Notes
 
-## Notes Importantes
-- Repository configuré pour github.com/dominicburkart/velib-mcp
-- Email configuré: dominic@dominic.computer
-- Approche TDD requise pour toutes les fonctionnalités
+- Repository: `github.com/dominicburkart/velib-mcp`
+- Default branch: `main`
+- Auto-deploy triggers on push to `main`

--- a/docs/development/project_prompt.md
+++ b/docs/development/project_prompt.md
@@ -1,19 +1,18 @@
-# Projet Claude Code : Serveur MCP Velib
+# Project Prompt Reference
 
-## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP. 
-- **Répertoire de travail** : `~/code/velib-mcp`
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
+This file preserves the original project brief for historical context. For current development guidance, see [`CLAUDE.md`](../../CLAUDE.md) in the repo root.
 
-## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
+## Original Brief
 
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
+Build a high-performance cloud MCP server in Rust that makes the following Paris Open Data datasets accessible to AI assistants:
 
-**But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
+- **Real-time availability**: <https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/>
+- **Station locations**: <https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/>
 
-[... rest of the original prompt content ...]
+**Goal**: Enable AI assistants to answer transport planning and journey flow questions using live Vélib data.
+
+**Constraints**:
+- Deploy to Scaleway Container Serverless
+- Use TDD throughout
+- Support parallel development via git worktrees
+- Tools: `git`, `cargo`, `podman`, `scw` CLI, `gh` CLI

--- a/tests/station_invariants_tests.rs
+++ b/tests/station_invariants_tests.rs
@@ -1,0 +1,123 @@
+//! Tests for untested invariants in VelibStation, StationReference, and BikeAvailability.
+
+use chrono::Utc;
+use velib_mcp::types::{
+    BikeAvailability, BikeTypeFilter, Coordinates, DataFreshness, ServiceCapabilities,
+    StationReference, StationStatus, RealTimeStatus, VelibStation,
+};
+
+fn paris_coords() -> Coordinates {
+    Coordinates::new(48.8566, 2.3522)
+}
+
+fn make_reference(code: &str, name: &str, capacity: u16) -> StationReference {
+    StationReference {
+        station_code: code.to_string(),
+        name: name.to_string(),
+        coordinates: paris_coords(),
+        capacity,
+        capabilities: ServiceCapabilities::default(),
+    }
+}
+
+// --- StationReference::validate() ---
+
+#[test]
+fn station_reference_validate_rejects_empty_code() {
+    let r = make_reference("", "Good Name", 20);
+    let err = r.validate().unwrap_err();
+    assert!(err.contains("code"), "Expected error about code, got: {err}");
+}
+
+#[test]
+fn station_reference_validate_rejects_empty_name() {
+    let r = make_reference("ABC", "", 20);
+    let err = r.validate().unwrap_err();
+    assert!(err.contains("name"), "Expected error about name, got: {err}");
+}
+
+#[test]
+fn station_reference_validate_rejects_zero_capacity() {
+    let r = make_reference("ABC", "Good Name", 0);
+    assert!(r.validate().is_err());
+}
+
+// --- VelibStation::is_operational() ---
+
+#[test]
+fn station_is_operational_true_when_no_real_time_data() {
+    let station = VelibStation::new(make_reference("X1", "Test", 10));
+    assert!(station.is_operational(), "Should be operational without real-time data");
+}
+
+#[test]
+fn station_is_operational_false_when_closed() {
+    let rt = RealTimeStatus {
+        bikes: BikeAvailability::new(0, 0),
+        available_docks: 10,
+        status: StationStatus::Closed,
+        last_update: Utc::now(),
+        data_freshness: DataFreshness::Fresh,
+    };
+    let station = VelibStation::new(make_reference("X2", "Test", 10)).with_real_time(rt);
+    assert!(!station.is_operational());
+}
+
+#[test]
+fn station_is_operational_false_when_maintenance() {
+    let rt = RealTimeStatus {
+        bikes: BikeAvailability::new(2, 1),
+        available_docks: 7,
+        status: StationStatus::Maintenance,
+        last_update: Utc::now(),
+        data_freshness: DataFreshness::Fresh,
+    };
+    let station = VelibStation::new(make_reference("X3", "Test", 10)).with_real_time(rt);
+    assert!(!station.is_operational());
+}
+
+// --- VelibStation::has_available_docks() ---
+
+#[test]
+fn station_has_available_docks_returns_false_without_real_time() {
+    let station = VelibStation::new(make_reference("D1", "Test", 20));
+    assert!(!station.has_available_docks(1));
+}
+
+#[test]
+fn station_has_available_docks_exact_boundary() {
+    let rt = RealTimeStatus {
+        bikes: BikeAvailability::new(5, 5),
+        available_docks: 3,
+        status: StationStatus::Open,
+        last_update: Utc::now(),
+        data_freshness: DataFreshness::Fresh,
+    };
+    let station = VelibStation::new(make_reference("D2", "Test", 20)).with_real_time(rt);
+    assert!(station.has_available_docks(3));  // exactly 3 docks available
+    assert!(!station.has_available_docks(4)); // one more than available
+}
+
+// --- BikeAvailability::total() saturation ---
+
+#[test]
+fn bike_availability_total_saturates_at_u16_max() {
+    let bikes = BikeAvailability::new(u16::MAX, 1);
+    assert_eq!(bikes.total(), u16::MAX, "saturating_add should not overflow");
+}
+
+// --- has_available_bikes with no bikes ---
+
+#[test]
+fn station_has_available_bikes_false_when_only_wrong_type() {
+    let rt = RealTimeStatus {
+        bikes: BikeAvailability::new(5, 0), // only mechanical
+        available_docks: 5,
+        status: StationStatus::Open,
+        last_update: Utc::now(),
+        data_freshness: DataFreshness::Fresh,
+    };
+    let station = VelibStation::new(make_reference("B1", "Test", 20)).with_real_time(rt);
+    assert!(!station.has_available_bikes(&BikeTypeFilter::ElectricOnly));
+    assert!(station.has_available_bikes(&BikeTypeFilter::MechanicalOnly));
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **CLAUDE.md**: Reduced from 8.4 KB to ~1.5 KB. Removed the 150-line multi-agent process methodology section (templates, metrics, phase descriptions) that was development-process bloat unrelated to working on the codebase. Retained: key files table, dev commands, architecture, worktree instructions. Switched entirely to English for consistency.
- **README.md**: Cut the "Integration with Other AI Tools" collapsed section — the Cursor/Le Chat/Windsurf/ChatGPT entries contained no useful information beyond "install and run." Added a concise table for the 5 MCP tools and a generic "other MCP clients" paragraph. Removed duplicate CI badges (Security Audit and Test Coverage badges both linked to the same workflow as the Tests badge).
- **docs/api/mcp_schemas.md**: Fixed schema drift vs `src/types.rs`. The doc had wrong `StationStatus` variants (Operational/Installed/OutOfService vs actual Open/Closed/Maintenance), wrong `DataFreshness` levels (Fresh/Acceptable/Stale/Unavailable vs actual Fresh/Recent/Stale/VeryStale), and entirely wrong `ServiceCapabilities` fields. Now matches the code. Added a note at the top directing readers to `src/types.rs` as authoritative source. Removed the `BothRequired` `BikeTypeFilter` variant that doesn't exist in code.
- **docs/context/etat_actuel.md**: Was stale — said "Phase 2 ready to start" while code was fully implemented through Phase 4. Replaced with a completion table of all phases and removed the personal email/git config details.
- **docs/development/project_prompt.md**: Was a near-verbatim duplicate of CLAUDE.md's top section. Replaced with a short historical reference note pointing to CLAUDE.md for current guidance, and preserved the original brief concisely.

## Issues not changed

- `docs/api/mcp_interface_spec.md` and `docs/api/data_analysis.md`: These are written in French but contain accurate technical content (field tables, JSON schemas, error codes). They are consistent with the implementation and left unchanged — language standardisation is a separate concern.
- `.claude/etat_partage.json`: Machine-readable state file, left as-is.

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub and contains all key file paths and commands
- [ ] Verify README.md quick-start commands are accurate (`cargo install`, `claude config add-server`)
- [ ] Confirm `docs/api/mcp_schemas.md` struct definitions match `src/types.rs` exactly
- [ ] Check no broken relative links in docs

https://claude.ai/code/session_013S2o5a62ZxQk7XbNg9aYwt
EOF
)"