### PR TITLE
docs(velib-mcp): reduce bloat and standardize formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,227 +1,60 @@
-# Projet CLAUDE : Serveur MCP Velib
+# CLAUDE.md — Velib MCP Server
 
-## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP.
+## Role
+You are an expert Rust developer working on an open-source MCP server project.
 
-- **Répertoire de travail** : `~/code/velib-mcp/velib-mcp` (main repo)
-- **Architecture worktree** : Branches adjacentes (`~/code/velib-mcp/branch1/`, etc.)
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
+- **Working directory**: `~/code/velib-mcp/velib-mcp` (main repo)
+- **Worktree layout**: Adjacent branches at `~/code/velib-mcp/<branch>/`
+- **Available tools**: git, cargo, podman, scw CLI, gh CLI
+- **Target users**: AI assistants needing access to Paris Velib data
 
-### Structure du Projet
+This file is symlinked into all worktrees so context is shared.
+
+## Project Goal
+
+A high-performance cloud MCP server exposing two Paris open datasets to AI assistants:
+
+- **Real-time availability**: <https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/>
+- **Station locations**: <https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/>
+
+## Repository Layout
+
 ```
-~/code/velib-mcp/
-├── velib-mcp/              # Dépôt principal (ce répertoire)
-│   ├── CLAUDE.md           # Configuration Claude partagée
-│   ├── src/                # Code source
-│   ├── docs/               # Documentation
-│   └── ...                 # Fichiers du projet
-├── branch1/                # Worktree pour branche feature
-│   ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-│   └── ...                 # Fichiers spécifiques à la branche
-└── branch2/                # Autre worktree
-    ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-    └── ...                 # Fichiers spécifiques à la branche
+src/
+  main.rs          # entry point
+  mcp/             # MCP protocol implementation
+  data/            # data client and cache
+  types.rs         # core data structures
+  error.rs         # error types
+docs/
+  api/             # data analysis and MCP interface specs
+  context/         # project status tracking
+  development/     # development notes
+tests/             # integration tests
 ```
 
-**Important** : Ce fichier CLAUDE.md est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
+## Development Commands
 
-## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
-
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
-
-- **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
-
-## État Actuel du Projet
-
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
-
-### Architecture Technique
-- **Serveur MCP Rust** pour données Velib Paris
-- **Deux datasets principaux** :
-  - Disponibilité stations en temps réel
-  - Localisations et métadonnées des stations
-- **Déploiement Scaleway** via GitHub Actions
-- **Suite de tests complète** (18+ tests)
-- **Validations sécurité** incluant limites zone service 50km
-
-### Fichiers Importants
-- `/src/main.rs` - Point d'entrée principal
-- `/src/mcp/` - Implémentation protocole MCP
-- `/src/data/` - Client données et cache
-- `/src/types.rs` - Structures de données principales
-- `/docs/api/data_analysis.md` - Analyse données complète
-- `/docs/context/etat_actuel.md` - Suivi statut projet
-
-### Commandes Développement
 ```bash
-cargo test                     # Tests complets
-cargo fmt                      # Formatage code
-cargo clippy                   # Analyse statique
-cargo audit                    # Audit sécurité
+cargo test                                          # run all tests
+cargo fmt                                           # format code
+cargo clippy --all-targets --all-features -- -D warnings  # lint
+cargo audit                                         # security audit
 ```
 
-### Déploiement
-- **Cible** : Scaleway Container Serverless
-- **Déclencheur** : Push vers branche main
-- **Registry** : Scaleway Container Registry
-- **Build** : Containerisation Podman
+## Deployment
 
-### Gestion Worktrees
+Deployed to Scaleway Container Serverless on push to `main` via GitHub Actions.
+
+## Worktree Management
+
 ```bash
-# Créer nouveau worktree
+# Create a new worktree
 git worktree add ../branch-name branch-name
 cd ../branch-name
 ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
 
-# Supprimer worktree
+# Remove a worktree
 git worktree remove ../branch-name
 git worktree prune
 ```
-
-## Processus de Développement Multi-Agents
-
-### Architecture Optimisée pour Performance, Qualité et Autonomie
-
-Ce processus transforme l'approche linéaire traditionnelle en 5 phases parallèles pour maximiser l'efficacité d'équipe.
-
-#### Phase 1: Analyse Concurrente (PM + Test Designer)
-**Durée**: ~30 min | **Parallélisation**: PM et Test Designer travaillent simultanément
-
-**Product Manager (Rôle: Extraction de Valeur)**
-- Analyse issue GitHub avec template structuré
-- Extraction valeur métier claire et actionnable
-- Validation exigences avec dev-utilisateur
-- Production: Spécification fonctionnelle validée
-
-**Test Designer (Rôle: Planification Technique)**
-- Analyse technique parallèle de l'issue
-- Estimation nombre features/refactors uniques
-- Planification PRs et worktrees nécessaires
-- Production: Plan d'implémentation détaillé
-
-#### Phase 2: Fondation Tests (Test Designer)
-**Durée**: ~45 min | **Focus**: Environnement + Spécifications Test
-
-**Préparation Environnement**
-```bash
-# Création worktree optimisée avec template
-git worktree add ../feature-name feature/branch-name
-cd ../feature-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
-cargo test --no-run  # Pré-compilation dependencies
-```
-
-**Implémentation Tests TDD**
-- Tests d'intégration définissant comportement attendu
-- Tests unitaires pour composants critiques
-- Tests fuzz si applicable (données externes)
-- Validation: Tests échouent de manière attendue
-
-#### Phase 3: Sprint Implémentation (Ingénieur)
-**Durée**: Variable | **Focus**: Développement avec Validation Continue
-
-**Workflow Micro-Commits**
-```bash
-# Cycle développement optimisé
-while [[ $tests_failing ]]; do
-    # Implémentation incrémentale
-    cargo clippy --fix
-    cargo fmt
-    cargo test
-    git add -A && git commit -m "feat: micro-increment"
-done
-```
-
-**Intégration Continue Locale**
-- Validation automatique à chaque commit
-- Feedback temps réel des tests
-- Métriques qualité code continues
-- Résolution bloquants technique immédiate
-
-#### Phase 4: Révision Parallèle (Ingénieur + Réviseur)
-**Durée**: ~20 min | **Parallélisation**: Préparation + Analyse simultanées
-
-**Ingénieur (Préparation PR)**
-- Organisation commits en histoire cohérente
-- Rédaction description PR succincte
-- Validation finale checks locaux
-- Ouverture PR avec lien issue origine
-
-**Réviseur Senior (Analyse Qualité)**
-- Évaluation architecture et patterns Rust
-- Vérification couverture tests vs objectifs PM
-- Analyse lisibilité et extensibilité code
-- Validation sécurité et ergonomie
-
-**Boucle Feedback Structurée**
-- Critères évaluation standardisés
-- Dialogue constructif jusqu'accord
-- Résolution collaborative des points bloquants
-
-#### Phase 5: Intégration Automatisée (Ops)
-**Durée**: ~10 min | **Focus**: Déploiement et Validation
-
-**Merge et CI/CD**
-- Merge automatique post-approbation
-- Validation CI complète sur main
-- Monitoring santé déploiement
-- Métriques performance production
-
-### Templates et Checklists
-
-#### Template Analyse Issue (PM)
-```markdown
-## Valeur Métier
-- [ ] Problème utilisateur identifié
-- [ ] Solution proposée claire
-- [ ] Critères succès mesurables
-- [ ] Validation dev-utilisateur
-
-## Exigences Techniques
-- [ ] Contraintes techniques identifiées
-- [ ] Impact architecture évalué
-- [ ] Effort estimé (S/M/L/XL)
-```
-
-#### Checklist Qualité (Réviseur)
-```markdown
-## Architecture & Design
-- [ ] Patterns Rust idiomatiques respectés
-- [ ] Séparation responsabilités claire
-- [ ] Gestion erreurs appropriée
-- [ ] Performance optimisée
-
-## Tests & Couverture
-- [ ] Tests couvrent objectifs PM
-- [ ] Edge cases identifiés et testés
-- [ ] Intégration validée
-- [ ] Documentation à jour
-```
-
-### Métriques de Performance
-
-**Gains Attendus vs Processus Linéaire**
-- **Temps cycle**: -40% (parallélisation phases)
-- **Temps attente**: -60% (élimination handoffs)
-- **Qualité code**: +25% (validation continue)
-- **Autonomie équipe**: +50% (rôles auto-suffisants)
-
-### Intégration Architecture Existante
-
-Ce processus s'intègre parfaitement avec:
-- Architecture worktree existante (isolation parallèle)
-- CI/CD GitHub Actions (validation automatisée)
-- Hooks pre-commit (qualité continue)
-- Toolchain Rust standard (fmt, clippy, audit)

--- a/README.md
+++ b/README.md
@@ -1,95 +1,54 @@
 # Velib MCP Server
 
-[![Test Coverage](https://img.shields.io/badge/coverage-check%20actions-brightgreen)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml)
 [![Tests](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml)
-[![Security Audit](https://img.shields.io/badge/security-audit%20passing-brightgreen)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/velib-mcp#license)
-[![Rust Version](https://img.shields.io/badge/rust-latest%20stable-orange)](https://www.rust-lang.org/)
 [![Deploy Status](https://github.com/DominicBurkart/velib-mcp/actions/workflows/deploy.yml/badge.svg)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/deploy.yml)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](https://github.com/DominicBurkart/velib-mcp#license)
 
 A high-performance Model Context Protocol (MCP) server providing access to Paris Velib bike sharing data for AI assistants.
 
-## Quick Start - Install with Claude Code
-
-Install and use the Velib MCP server with Claude Code in one command:
+## Quick Start
 
 ```bash
-# Install and configure the server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-claude config add-server velib-mcp "cargo run --release -- --port 3000"
 ```
 
-Then use in Claude Code:
-```
-@velib find nearby stations at latitude 48.8566 longitude 2.3522
-@velib get station by code 16107
-@velib search stations by name "châtelet"
-```
+Then add to your MCP client config (example for Claude Code):
 
-## Overview
-
-This project exposes two key Parisian datasets through MCP:
-- **Real-time availability**: Current bike and dock availability at stations
-- **Station locations**: Geographic information and details about all Velib stations
-
-## Data Sources
-
-- [Velib Real-time Availability](https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/)
-- [Velib Station Locations](https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/)
-
-## Available Tools
-
-- `find_nearby_stations`: Find Velib stations within a radius of coordinates
-- `get_station_by_code`: Get detailed information about a specific station
-- `search_stations_by_name`: Search stations by name with optional fuzzy matching
-- `get_area_statistics`: Get aggregated statistics for a geographic area
-- `plan_bike_journey`: Plan a bike journey with pickup and dropoff suggestions
-
-## Integration with Other AI Tools
-
-<details>
-<summary>Click to expand integration guides</summary>
-
-### ChatGPT
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server on port 8080
-velib-mcp
-# Configure in ChatGPT Custom Instructions or use via API
-```
-
-### Cursor
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Add to Cursor's settings.json
+```json
 {
   "mcp.servers": {
     "velib": {
-      "command": "velib-mcp",
-      "args": ["--port", "8080"]
+      "command": "velib-mcp"
     }
   }
 }
 ```
 
-### Le Chat / Mistral
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server and use via API calls
-velib-mcp --port 8080
+Example prompts:
+```
+find nearby stations at latitude 48.8566 longitude 2.3522
+get station by code 16107
+search stations by name "châtelet"
 ```
 
-### Windsurf
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Configure in Windsurf MCP settings
-```
+## Overview
 
-</details>
+Exposes two Parisian open datasets through MCP:
+
+- **Real-time availability**: Current bike and dock availability at stations — [source](https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/)
+- **Station locations**: Geographic metadata for all Velib stations — [source](https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/)
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `find_nearby_stations` | Find stations within a radius of coordinates |
+| `get_station_by_code` | Get details for a specific station |
+| `search_stations_by_name` | Search stations by name (supports fuzzy matching) |
+| `get_area_statistics` | Aggregated statistics for a geographic bounding box |
+| `plan_bike_journey` | Suggest pickup and dropoff stations for a journey |
+
+See [`docs/api/mcp_interface_spec.md`](docs/api/mcp_interface_spec.md) for full schema details.
 
 ## Development
 
@@ -107,41 +66,33 @@ cd velib-mcp
 cargo build
 ```
 
-### Testing
+### Commands
 
 ```bash
-cargo test
-cargo fmt --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo audit
+cargo test                                          # run tests
+cargo fmt --check                                   # check formatting
+cargo clippy --all-targets --all-features -- -D warnings  # lint
+cargo audit                                         # security audit
 ```
 
-### Podman
+### Container
 
 ```bash
-# Build container image
 podman build -t velib-mcp .
-
-# Run container
 podman run -p 8080:8080 velib-mcp
 ```
 
 ## Deployment
 
-The project is configured for deployment to Scaleway Container Serverless via GitHub Actions on pushes to the main branch.
+Automatically deployed to Scaleway Container Serverless on push to `main` via GitHub Actions. See [`deploy_to_scaleway.sh`](deploy_to_scaleway.sh) and [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml).
 
 ## Architecture
 
 - **Language**: Rust
-- **Deployment**: Scaleway Container Serverless  
+- **Transport**: Scaleway Container Serverless
 - **CI/CD**: GitHub Actions
-- **Development**: Test-Driven Development approach
 - **Container**: Distroless Debian base image
 
 ## License
 
-Licensed under either of:
-- Apache License, Version 2.0
-- MIT License
-
-at your option.
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT License](LICENSE-MIT) at your option.

--- a/docs/api/data_analysis.md
+++ b/docs/api/data_analysis.md
@@ -1,171 +1,114 @@
-# Analyse des Données Velib - Phase 1
+# Velib Data Analysis
 
-## Vue d'ensemble
+## Overview
 
-Ce document analyse les deux jeux de données Velib disponibles via l'API Open Data de Paris :
+Two datasets are available via the Paris Open Data API:
 
-1. **Disponibilité temps réel** : État actuel des stations (vélos/emplacements disponibles)
-2. **Emplacements des stations** : Données de référence statiques des stations
+1. **Real-time availability** — current station state (bikes/docks available)
+2. **Station locations** — static station reference data
 
-## Dataset 1 : Disponibilité Temps Réel
+## Dataset 1: Real-Time Availability
 
-### Endpoint API
+### Endpoint
+
 ```
 https://opendata.paris.fr/api/records/1.0/search/?dataset=velib-disponibilite-en-temps-reel
 ```
 
-### Caractéristiques Techniques
-- **Format** : JSON (UTF-8)
-- **Standard** : GBFS 1.0
-- **Fréquence de mise à jour** : Chaque minute
-- **Accès** : Sans clé d'authentification
-- **Couverture** : ~1,400 stations sur 55 communes
+### Characteristics
 
-### Structure des Données
+- Format: JSON (UTF-8), GBFS 1.0
+- Update frequency: every minute
+- Authentication: none
+- Coverage: ~1,400 stations across 55 communes
 
-#### Champs Principaux
-| Champ | Type | Description | Exemple |
+### Fields
+
+#### Core
+
+| Field | Type | Description | Example |
 |-------|------|-------------|---------|
-| `name` | string | Nom de la station | "Rouget de L'isle - Watteau" |
-| `stationcode` | string | Identifiant unique de station | "32017" |
-| `coordonnees_geo` | array[float] | Coordonnées [lat, lon] | [48.936, 2.358] |
-| `capacity` | integer | Capacité totale de la station | 22 |
-| `numbikesavailable` | integer | Vélos disponibles (total) | 15 |
-| `numdocksavailable` | integer | Emplacements libres | 7 |
+| `name` | string | Station name | `"Rouget de L'isle - Watteau"` |
+| `stationcode` | string | Unique station ID | `"32017"` |
+| `coordonnees_geo` | float[2] | `[lat, lon]` | `[48.936, 2.358]` |
+| `capacity` | integer | Total dock capacity | `22` |
+| `numbikesavailable` | integer | Total bikes available | `15` |
+| `numdocksavailable` | integer | Free docks | `7` |
 
-#### Détail par Type de Vélo
-| Champ | Type | Description |
+#### Bike type breakdown
+
+| Field | Type | Description |
 |-------|------|-------------|
-| `ebike` | integer | Vélos électriques disponibles |
-| `mechanical` | integer | Vélos mécaniques disponibles |
+| `ebike` | integer | Electric bikes available |
+| `mechanical` | integer | Mechanical bikes available |
 
-#### États de la Station
-| Champ | Type | Valeurs | Description |
-|-------|------|---------|-------------|
-| `is_renting` | string | "OUI"/"NON" | Location autorisée |
-| `is_installed` | string | "OUI"/"NON" | Station opérationnelle |
-| `is_returning` | string | "OUI"/"NON" | Retour autorisé |
+#### Station state flags
 
-#### Données Temporelles
-| Champ | Type | Format | Exemple |
+| Field | Type | Values | Description |
+|-------|------|--------|-------------|
+| `is_renting` | string | `"OUI"`/`"NON"` | Rentals allowed |
+| `is_installed` | string | `"OUI"`/`"NON"` | Station is operational |
+| `is_returning` | string | `"OUI"`/`"NON"` | Returns allowed |
+
+#### Timestamps
+
+| Field | Type | Format | Example |
 |-------|------|--------|---------|
-| `duedate` | string | ISO 8601 | "2025-06-14T19:31:22+00:00" |
-| `record_timestamp` | string | ISO 8601 | "2025-06-14T19:31:22+00:00" |
+| `duedate` | string | ISO 8601 | `"2025-06-14T19:31:22+00:00"` |
+| `record_timestamp` | string | ISO 8601 | `"2025-06-14T19:31:22+00:00"` |
 
-#### Informations Administratives
-| Champ | Type | Description |
+#### Administrative
+
+| Field | Type | Description |
 |-------|------|-------------|
-| `nom_arrondissement_communes` | string | Commune/arrondissement |
-| `code_insee_commune` | string | Code INSEE administratif |
+| `nom_arrondissement_communes` | string | Commune / arrondissement |
+| `code_insee_commune` | string | INSEE administrative code |
 
-### Contraintes et Validations
-- **Coordonnées** : Précision décimale de 7-8 places (niveau mètre)
-- **Capacité** : Observée entre 12-60 emplacements
-- **Disponibilité** : 0 ≤ `numbikesavailable` ≤ `capacity`
-- **Cohérence** : `numbikesavailable` = `ebike` + `mechanical`
-- **Emplacements** : `numdocksavailable` = `capacity` - `numbikesavailable`
+### Invariants
 
-## Dataset 2 : Emplacements des Stations
+- `numbikesavailable` = `ebike` + `mechanical`
+- `numdocksavailable` = `capacity` − `numbikesavailable`
+- `0 ≤ numbikesavailable ≤ capacity`
+- Coordinate precision: 7–8 decimal places
+- Observed capacity range: 12–60 docks
 
-### Endpoint API
+## Dataset 2: Station Locations
+
+### Endpoint
+
 ```
 https://opendata.paris.fr/api/records/1.0/search/?dataset=velib-emplacement-des-stations
 ```
 
-### Caractéristiques Techniques
-- **Format** : JSON (UTF-8)
-- **Nature** : Données de référence statiques
-- **Mise à jour** : Occasionnelle (ajout/suppression de stations)
-- **Accès** : Sans clé d'authentification
+### Characteristics
 
-### Structure des Données
+- Format: JSON (UTF-8)
+- Nature: static reference data
+- Update frequency: occasional (station additions/removals)
+- Authentication: none
 
-#### Champs de Référence
-| Champ | Type | Description | Exemple |
+### Fields
+
+| Field | Type | Description | Example |
 |-------|------|-------------|---------|
-| `stationcode` | string | Identifiant unique (même que temps réel) | "32017" |
-| `name` | string | Nom de localisation | "Basilique" |
-| `capacity` | integer | Capacité maximale | 22 |
-| `coordonnees_geo` | array[float] | Position [lat, lon] | [48.936, 2.358] |
+| `stationcode` | string | Unique ID (same key as real-time) | `"32017"` |
+| `name` | string | Location name | `"Basilique"` |
+| `capacity` | integer | Maximum capacity | `22` |
+| `coordonnees_geo` | float[2] | `[lat, lon]` | `[48.936, 2.358]` |
 
-### Relation entre les Datasets
+## Dataset Relationship
 
-#### Clé de Liaison
-- **Champ commun** : `stationcode`
-- **Cardinalité** : 1:1 (une station = un code unique)
-- **Intégrité** : Toutes les stations temps réel doivent avoir une référence
+- **Join key**: `stationcode` (1:1)
+- Every real-time record must have a corresponding location entry.
 
-#### Différences Fonctionnelles
-| Aspect | Temps Réel | Emplacements |
-|--------|------------|-------------|
-| **Fréquence** | Minute | Occasionnelle |
-| **Données** | État dynamique | Métadonnées statiques |
-| **Utilisation** | Planification immédiate | Référence géographique |
+| Aspect | Real-time | Locations |
+|--------|-----------|-----------|
+| Update frequency | Every minute | Occasional |
+| Data type | Dynamic state | Static metadata |
+| Primary use | Live planning | Geographic reference |
 
-## Opportunités d'Intégration MCP
+## Update Strategy
 
-### Cas d'Usage Identifiés
-
-1. **Planification de trajets**
-   - Recherche de stations proches avec vélos disponibles
-   - Calcul d'itinéraires avec disponibilité temps réel
-
-2. **Analyse spatiale**
-   - Densité de stations par zone
-   - Rayons de couverture géographique
-
-3. **Monitoring d'état**
-   - Stations hors service ou pleines
-   - Tendances de disponibilité
-
-4. **Optimisation logistique**
-   - Répartition des vélos par type
-   - Prédiction de demande par zone
-
-### Défis Techniques
-
-1. **Synchronisation des données**
-   - Cohérence entre datasets
-   - Gestion des stations temporairement indisponibles
-
-2. **Performance**
-   - Cache intelligent pour données quasi-statiques
-   - Optimisation des requêtes géospatiales
-
-3. **Fiabilité**
-   - Gestion des pannes d'API
-   - Validation de la cohérence des données
-
-## Recommandations pour l'Architecture MCP
-
-### Modèle de Données Unifié
-```rust
-struct VelibStation {
-    // Référence statique
-    station_code: String,
-    name: String,
-    capacity: u16,
-    coordinates: (f64, f64), // (lat, lon)
-    
-    // État temps réel
-    available_bikes: u16,
-    available_ebikes: u16,
-    available_mechanical: u16,
-    available_docks: u16,
-    
-    // États opérationnels
-    is_renting: bool,
-    is_installed: bool,
-    is_returning: bool,
-    
-    // Métadonnées
-    commune: Option<String>,
-    insee_code: Option<String>,
-    last_updated: DateTime<Utc>,
-}
-```
-
-### Stratégie de Mise à Jour
-1. **Référence** : Synchronisation quotidienne des emplacements
-2. **Temps réel** : Polling toutes les 2-3 minutes (respect du rate limiting)
-3. **Cache** : TTL de 2 minutes pour les données temps réel
+- **Reference data**: sync daily
+- **Real-time data**: poll every 2–3 minutes (respects rate limits)
+- **Cache TTL**: 2 minutes for real-time data

--- a/docs/api/mcp_interface_spec.md
+++ b/docs/api/mcp_interface_spec.md
@@ -1,50 +1,25 @@
-# Spécification des Interfaces MCP - Velib Server
+# MCP Interface Specification
 
-## Vue d'ensemble
+## Server Info
 
-Ce document définit les interfaces MCP (Model Context Protocol) exposées par le serveur Velib pour l'accès aux données de vélos en libre-service parisien.
+- **Name**: `velib-mcp`
+- **Version**: `1.0.0`
+- **Capabilities**: `resources`, `tools`
+- **Transport**: JSON-RPC 2.0 over HTTP/WebSocket, UTF-8, default port 8080
 
-## Architecture MCP
+## Resources
 
-### Serveur MCP
-- **Nom** : `velib-mcp`
-- **Version** : `1.0.0`
-- **Description** : Serveur MCP pour les données Velib Paris
-- **Capacités** : `resources`, `tools`
+### `velib://stations/reference`
 
-### Transport
-- **Protocole** : JSON-RPC 2.0 over HTTP/WebSocket
-- **Encoding** : UTF-8
-- **Port par défaut** : 8080
+Full catalogue of Velib stations with static metadata.
 
-## Resources MCP
-
-### 1. Stations de Référence
-
-#### Resource URI
-```
-velib://stations/reference
-```
-
-#### Description
-Catalogue complet des stations Velib avec leurs métadonnées statiques.
-
-#### Content Type
-```
-application/json
-```
-
-#### Exemple de Contenu
 ```json
 {
   "stations": [
     {
       "station_code": "32017",
       "name": "Rouget de L'isle - Watteau",
-      "coordinates": {
-        "latitude": 48.936268,
-        "longitude": 2.358866
-      },
+      "coordinates": { "latitude": 48.936268, "longitude": 2.358866 },
       "capacity": 22,
       "commune": "Issy-les-Moulineaux"
     }
@@ -56,38 +31,18 @@ application/json
 }
 ```
 
-### 2. Disponibilité Temps Réel
+### `velib://stations/realtime`
 
-#### Resource URI
-```
-velib://stations/realtime
-```
+Current availability for all stations.
 
-#### Description
-État actuel de toutes les stations avec disponibilité des vélos et emplacements.
-
-#### Content Type
-```
-application/json
-```
-
-#### Exemple de Contenu
 ```json
 {
   "stations": [
     {
       "station_code": "32017",
-      "bikes": {
-        "mechanical": 8,
-        "electric": 4
-      },
+      "bikes": { "mechanical": 8, "electric": 4 },
       "available_docks": 10,
-      "service": {
-        "renting_enabled": true,
-        "returning_enabled": true,
-        "installed": true
-      },
-      "status": "Operational",
+      "status": "OPEN",
       "last_updated": "2025-06-14T19:31:22Z"
     }
   ],
@@ -98,121 +53,76 @@ application/json
 }
 ```
 
-### 3. Stations Consolidées
+### `velib://stations/complete`
 
-#### Resource URI
-```
-velib://stations/complete
-```
+Merged view combining reference and real-time data.
 
-#### Description
-Vue complète combinant données de référence et temps réel.
+### `velib://health`
 
-#### Content Type
-```
-application/json
-```
-
-## Tools MCP
-
-### 1. Recherche de Stations Proches
-
-#### Tool Name
-```
-find_nearby_stations
-```
-
-#### Description
-Trouve les stations Velib dans un rayon donné autour d'un point.
-
-#### Input Schema
 ```json
 {
-  "type": "object",
-  "properties": {
-    "latitude": {
-      "type": "number",
-      "minimum": 48.7,
-      "maximum": 49.0,
-      "description": "Latitude du point central"
-    },
-    "longitude": {
-      "type": "number", 
-      "minimum": 2.0,
-      "maximum": 2.6,
-      "description": "Longitude du point central"
-    },
-    "radius_meters": {
-      "type": "integer",
-      "minimum": 100,
-      "maximum": 5000,
-      "default": 500,
-      "description": "Rayon de recherche en mètres"
-    },
-    "limit": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 100,
-      "default": 10,
-      "description": "Nombre maximum de stations"
-    },
-    "availability_filter": {
-      "type": "object",
-      "properties": {
-        "min_bikes": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Minimum de vélos disponibles"
-        },
-        "min_docks": {
-          "type": "integer", 
-          "minimum": 0,
-          "description": "Minimum d'emplacements libres"
-        },
-        "bike_type": {
-          "type": "string",
-          "enum": ["mechanical", "electric", "any"],
-          "default": "any",
-          "description": "Type de vélos requis"
-        }
-      }
-    }
+  "status": "healthy",
+  "version": "1.0.0",
+  "uptime_seconds": 86400,
+  "data_sources": {
+    "real_time": { "status": "healthy", "last_update": "2025-06-14T19:31:22Z", "lag_seconds": 45 },
+    "reference": { "status": "healthy", "last_update": "2025-06-14T06:00:00Z" }
   },
-  "required": ["latitude", "longitude"]
+  "cache_stats": { "hit_rate": 0.85, "entries": 1400 }
 }
 ```
 
-#### Output Schema
+## Tools
+
+### `find_nearby_stations`
+
+Find stations within a radius of a coordinate.
+
+**Input**
+
 ```json
 {
   "type": "object",
+  "required": ["latitude", "longitude"],
   "properties": {
-    "stations": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/VelibStation"
-      }
-    },
-    "search_metadata": {
+    "latitude":      { "type": "number",  "minimum": 48.7, "maximum": 49.0 },
+    "longitude":     { "type": "number",  "minimum": 2.0,  "maximum": 2.6 },
+    "radius_meters": { "type": "integer", "minimum": 100,  "maximum": 5000, "default": 500 },
+    "limit":         { "type": "integer", "minimum": 1,    "maximum": 100,  "default": 10 },
+    "availability_filter": {
       "type": "object",
       "properties": {
-        "query_point": {
-          "type": "object",
-          "properties": {
-            "latitude": {"type": "number"},
-            "longitude": {"type": "number"}
-          }
-        },
-        "radius_meters": {"type": "integer"},
-        "total_found": {"type": "integer"},
-        "search_time_ms": {"type": "integer"}
+        "min_bikes": { "type": "integer", "minimum": 0 },
+        "min_docks": { "type": "integer", "minimum": 0 },
+        "bike_type": { "type": "string",  "enum": ["mechanical", "electric", "any"], "default": "any" }
       }
     }
   }
 }
 ```
 
-#### Exemple d'Utilisation
+**Output**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "stations": { "type": "array", "items": { "$ref": "#/definitions/VelibStation" } },
+    "search_metadata": {
+      "type": "object",
+      "properties": {
+        "query_point":    { "type": "object", "properties": { "latitude": {"type": "number"}, "longitude": {"type": "number"} } },
+        "radius_meters":  { "type": "integer" },
+        "total_found":    { "type": "integer" },
+        "search_time_ms": { "type": "integer" }
+      }
+    }
+  }
+}
+```
+
+**Example call**
+
 ```json
 {
   "name": "find_nearby_stations",
@@ -221,132 +131,86 @@ Trouve les stations Velib dans un rayon donné autour d'un point.
     "longitude": 2.3522,
     "radius_meters": 1000,
     "limit": 5,
-    "availability_filter": {
-      "min_bikes": 2,
-      "bike_type": "electric"
-    }
+    "availability_filter": { "min_bikes": 2, "bike_type": "electric" }
   }
 }
 ```
 
-### 2. Obtenir Station par Code
+### `get_station_by_code`
 
-#### Tool Name
-```
-get_station_by_code
-```
+Fetch complete information for a specific station.
 
-#### Description
-Récupère les informations complètes d'une station spécifique.
+**Input**
 
-#### Input Schema
 ```json
 {
   "type": "object",
+  "required": ["station_code"],
   "properties": {
-    "station_code": {
-      "type": "string",
-      "pattern": "^[0-9]+$",
-      "description": "Code unique de la station"
-    },
-    "include_real_time": {
-      "type": "boolean",
-      "default": true,
-      "description": "Inclure les données temps réel"
-    }
-  },
-  "required": ["station_code"]
-}
-```
-
-#### Output Schema
-```json
-{
-  "type": "object",
-  "properties": {
-    "station": {
-      "$ref": "#/definitions/VelibStation"
-    },
-    "found": {
-      "type": "boolean",
-      "description": "Station trouvée ou non"
-    }
+    "station_code":     { "type": "string",  "pattern": "^[0-9]+$" },
+    "include_real_time": { "type": "boolean", "default": true }
   }
 }
 ```
 
-### 3. Recherche par Nom de Station
+**Output**
 
-#### Tool Name
-```
-search_stations_by_name
-```
-
-#### Description
-Recherche textuelle dans les noms de stations.
-
-#### Input Schema
 ```json
 {
   "type": "object",
   "properties": {
-    "query": {
-      "type": "string",
-      "minLength": 2,
-      "description": "Terme de recherche dans le nom"
-    },
-    "limit": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 50,
-      "default": 10,
-      "description": "Nombre maximum de résultats"
-    },
-    "fuzzy": {
-      "type": "boolean",
-      "default": true,
-      "description": "Recherche approximative autorisée"
-    }
-  },
-  "required": ["query"]
+    "station": { "$ref": "#/definitions/VelibStation" },
+    "found":   { "type": "boolean" }
+  }
 }
 ```
 
-### 4. Statistiques de Zone
+### `search_stations_by_name`
 
-#### Tool Name
-```
-get_area_statistics
-```
+Text search over station names.
 
-#### Description
-Calcule des statistiques agrégées pour une zone géographique.
+**Input**
 
-#### Input Schema
 ```json
 {
   "type": "object",
+  "required": ["query"],
+  "properties": {
+    "query": { "type": "string", "minLength": 2 },
+    "limit": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 },
+    "fuzzy": { "type": "boolean", "default": true }
+  }
+}
+```
+
+### `get_area_statistics`
+
+Aggregated statistics for a geographic bounding box.
+
+**Input**
+
+```json
+{
+  "type": "object",
+  "required": ["bounds"],
   "properties": {
     "bounds": {
       "type": "object",
+      "required": ["north", "south", "east", "west"],
       "properties": {
-        "north": {"type": "number"},
-        "south": {"type": "number"},
-        "east": {"type": "number"},
-        "west": {"type": "number"}
-      },
-      "required": ["north", "south", "east", "west"]
+        "north": { "type": "number" },
+        "south": { "type": "number" },
+        "east":  { "type": "number" },
+        "west":  { "type": "number" }
+      }
     },
-    "include_real_time": {
-      "type": "boolean",
-      "default": true
-    }
-  },
-  "required": ["bounds"]
+    "include_real_time": { "type": "boolean", "default": true }
+  }
 }
 ```
 
-#### Output Schema
+**Output**
+
 ```json
 {
   "type": "object",
@@ -354,83 +218,51 @@ Calcule des statistiques agrégées pour une zone géographique.
     "area_stats": {
       "type": "object",
       "properties": {
-        "total_stations": {"type": "integer"},
-        "operational_stations": {"type": "integer"},
-        "total_capacity": {"type": "integer"},
+        "total_stations":      { "type": "integer" },
+        "operational_stations": { "type": "integer" },
+        "total_capacity":      { "type": "integer" },
         "available_bikes": {
           "type": "object",
           "properties": {
-            "mechanical": {"type": "integer"},
-            "electric": {"type": "integer"},
-            "total": {"type": "integer"}
+            "mechanical": { "type": "integer" },
+            "electric":   { "type": "integer" },
+            "total":      { "type": "integer" }
           }
         },
-        "available_docks": {"type": "integer"},
-        "occupancy_rate": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1,
-          "description": "Taux d'occupation (0-1)"
-        }
+        "available_docks": { "type": "integer" },
+        "occupancy_rate":  { "type": "number", "minimum": 0, "maximum": 1 }
       }
-    },
-    "bounds": {"$ref": "#/definitions/GeographicBounds"}
+    }
   }
 }
 ```
 
-### 5. Itinéraire avec Vélos
+### `plan_bike_journey`
 
-#### Tool Name
-```
-plan_bike_journey
-```
+Suggest pickup and dropoff stations for a journey.
 
-#### Description
-Planifie un trajet en suggérant stations de départ et d'arrivée.
+**Input**
 
-#### Input Schema
 ```json
 {
   "type": "object",
+  "required": ["origin", "destination"],
   "properties": {
-    "origin": {
-      "type": "object",
-      "properties": {
-        "latitude": {"type": "number"},
-        "longitude": {"type": "number"}
-      },
-      "required": ["latitude", "longitude"]
-    },
-    "destination": {
-      "type": "object", 
-      "properties": {
-        "latitude": {"type": "number"},
-        "longitude": {"type": "number"}
-      },
-      "required": ["latitude", "longitude"]
-    },
+    "origin":      { "type": "object", "required": ["latitude", "longitude"], "properties": { "latitude": {"type": "number"}, "longitude": {"type": "number"} } },
+    "destination": { "type": "object", "required": ["latitude", "longitude"], "properties": { "latitude": {"type": "number"}, "longitude": {"type": "number"} } },
     "preferences": {
       "type": "object",
       "properties": {
-        "bike_type": {
-          "type": "string",
-          "enum": ["mechanical", "electric", "any"],
-          "default": "any"
-        },
-        "max_walk_distance": {
-          "type": "integer",
-          "default": 500,
-          "description": "Distance max à pied en mètres"
-        }
+        "bike_type":          { "type": "string",  "enum": ["mechanical", "electric", "any"], "default": "any" },
+        "max_walk_distance": { "type": "integer", "default": 500, "description": "Max walking distance in meters" }
       }
     }
-  },
-  "required": ["origin", "destination"]
+  }
 }
 ```
 
-#### Output Schema
+**Output**
+
 ```json
 {
   "type": "object",
@@ -438,28 +270,18 @@ Planifie un trajet en suggérant stations de départ et d'arrivée.
     "journey": {
       "type": "object",
       "properties": {
-        "pickup_stations": {
-          "type": "array",
-          "items": {"$ref": "#/definitions/StationWithDistance"}
-        },
-        "dropoff_stations": {
-          "type": "array", 
-          "items": {"$ref": "#/definitions/StationWithDistance"}
-        },
+        "pickup_stations":  { "type": "array", "items": { "$ref": "#/definitions/StationWithDistance" } },
+        "dropoff_stations": { "type": "array", "items": { "$ref": "#/definitions/StationWithDistance" } },
         "recommendations": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "pickup_station": {"$ref": "#/definitions/VelibStation"},
-              "dropoff_station": {"$ref": "#/definitions/VelibStation"},
-              "walk_to_pickup": {"type": "integer"},
-              "walk_from_dropoff": {"type": "integer"},
-              "confidence_score": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1
-              }
+              "pickup_station":   { "$ref": "#/definitions/VelibStation" },
+              "dropoff_station":  { "$ref": "#/definitions/VelibStation" },
+              "walk_to_pickup":   { "type": "integer" },
+              "walk_from_dropoff": { "type": "integer" },
+              "confidence_score": { "type": "number", "minimum": 0, "maximum": 1 }
             }
           }
         }
@@ -469,81 +291,32 @@ Planifie un trajet en suggérant stations de départ et d'arrivée.
 }
 ```
 
-## Gestion des Erreurs
+## Error Codes
 
-### Codes d'Erreur Standard
+| Code | Constant | Meaning |
+|------|----------|---------|
+| `-32001` | `STATION_NOT_FOUND` | Station code does not exist |
+| `-32002` | `INVALID_COORDINATES` | Coordinates outside service area |
+| `-32003` | `REALTIME_UNAVAILABLE` | Real-time data temporarily unavailable |
+| `-32004` | `RADIUS_TOO_LARGE` | Search radius exceeds maximum |
+| `-32005` | `LIMIT_EXCEEDED` | Result limit exceeds maximum |
+
+**Error response shape**
+
 ```json
-{
-  "error": {
-    "code": -32001,
-    "message": "Station not found",
-    "data": {
-      "station_code": "99999",
-      "error_type": "STATION_NOT_FOUND"
-    }
-  }
-}
+{ "error": { "code": -32001, "message": "Station not found", "data": { "station_code": "99999", "error_type": "STATION_NOT_FOUND" } } }
 ```
 
-### Types d'Erreurs
-- `-32001` : Station non trouvée
-- `-32002` : Coordonnées invalides  
-- `-32003` : Données temps réel indisponibles
-- `-32004` : Rayon de recherche trop large
-- `-32005` : Limite de résultats dépassée
+## Rate Limits
 
-## Rate Limiting
+| Scope | Limit |
+|-------|-------|
+| Resources | 60 req/min |
+| Tools | 100 req/min |
+| Burst | 10 req/s |
 
-### Limites par Défaut
-- **Resources** : 60 requêtes/minute
-- **Tools** : 100 requêtes/minute
-- **Burst** : 10 requêtes/seconde
+Response headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`.
 
-### Headers de Réponse
-```
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1640995200
-```
+## Authentication
 
-## Authentification
-
-### Mode Public
-- Aucune authentification requise
-- Rate limiting appliqué par IP
-
-### Mode API Key (Futur)
-```http
-Authorization: Bearer <api_key>
-```
-
-## Métadonnées de Santé
-
-### Resource URI
-```
-velib://health
-```
-
-#### Contenu
-```json
-{
-  "status": "healthy",
-  "version": "1.0.0",
-  "uptime_seconds": 86400,
-  "data_sources": {
-    "real_time": {
-      "status": "healthy",
-      "last_update": "2025-06-14T19:31:22Z",
-      "lag_seconds": 45
-    },
-    "reference": {
-      "status": "healthy", 
-      "last_update": "2025-06-14T06:00:00Z"
-    }
-  },
-  "cache_stats": {
-    "hit_rate": 0.85,
-    "entries": 1400
-  }
-}
-```
+Currently none required. Rate limiting is applied per IP. API key support is planned.

--- a/docs/api/mcp_schemas.md
+++ b/docs/api/mcp_schemas.md
@@ -1,361 +1,143 @@
-# Schémas de Données MCP - Velib Server
+# MCP Data Schemas
 
-## Vue d'ensemble
+This document defines the canonical data types used by the Velib MCP server. The authoritative Rust source is [`src/types.rs`](../../src/types.rs).
 
-Ce document définit les schémas de données formels pour l'exposition des données Velib via le protocole MCP (Model Context Protocol).
+## Core Types
 
-## Types de Base
+### `Coordinates`
 
-### Coordonnées Géographiques
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Coordinates {
-    /// Latitude en degrés décimaux
-    pub latitude: f64,
-    /// Longitude en degrés décimaux  
-    pub longitude: f64,
+    pub latitude: f64,   // decimal degrees
+    pub longitude: f64,  // decimal degrees
 }
 ```
 
-### État de Station
+Valid Paris metro area: latitude 48.7–49.0, longitude 2.0–2.6.
+Service area check: within 50 km of Paris City Hall (48.8565° N, 2.3514° E).
+
+### `StationStatus`
+
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum StationStatus {
-    /// Station opérationnelle
-    Operational,
-    /// Station installée mais non opérationnelle
-    Installed,
-    /// Station en maintenance
-    Maintenance,
-    /// Station hors service
-    OutOfService,
+    #[serde(rename = "OPEN")]        Open,
+    #[serde(rename = "CLOSED")]      Closed,
+    #[serde(rename = "MAINTENANCE")] Maintenance,
 }
 ```
 
-### Capacités de Service
+### `ServiceCapabilities`
+
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ServiceCapabilities {
-    /// Location de vélos autorisée
-    pub renting_enabled: bool,
-    /// Retour de vélos autorisé
-    pub returning_enabled: bool,
-    /// Station installée et accessible
-    pub installed: bool,
+    pub accepts_credit_card: bool,
+    pub has_charging_station: bool,
+    pub is_virtual_station: bool,
 }
 ```
 
-## Schémas Principaux
+### `BikeAvailability`
 
-### Station de Référence
 ```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct StationReference {
-    /// Identifiant unique de la station
-    pub station_code: String,
-    
-    /// Nom descriptif de la station
-    pub name: String,
-    
-    /// Coordonnées géographiques précises
-    pub coordinates: Coordinates,
-    
-    /// Capacité totale de la station
-    pub capacity: u16,
-    
-    /// Commune ou arrondissement
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub commune: Option<String>,
-    
-    /// Code INSEE de la commune
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub insee_code: Option<String>,
-}
-```
-
-### Disponibilité Temps Réel
-```rust
-use chrono::{DateTime, Utc};
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BikeAvailability {
-    /// Vélos mécaniques disponibles
     pub mechanical: u16,
-    
-    /// Vélos électriques disponibles
     pub electric: u16,
 }
-
-impl BikeAvailability {
-    /// Total de vélos disponibles
-    pub fn total(&self) -> u16 {
-        self.mechanical + self.electric
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct RealTimeStatus {
-    /// Référence à la station
-    pub station_code: String,
-    
-    /// Vélos disponibles par type
-    pub bikes: BikeAvailability,
-    
-    /// Emplacements libres pour retour
-    pub available_docks: u16,
-    
-    /// Capacités de service actuelles
-    pub service: ServiceCapabilities,
-    
-    /// État général de la station
-    pub status: StationStatus,
-    
-    /// Horodatage de dernière mise à jour
-    pub last_updated: DateTime<Utc>,
-    
-    /// Horodatage de validité des données
-    pub valid_until: DateTime<Utc>,
-}
 ```
 
-### Station Complète (Vue Consolidée)
-```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct VelibStation {
-    /// Données de référence de la station
-    #[serde(flatten)]
-    pub reference: StationReference,
-    
-    /// État temps réel actuel
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub real_time: Option<RealTimeStatus>,
-    
-    /// Indicateur de fraîcheur des données
-    pub data_freshness: DataFreshness,
-}
+`total()` returns `mechanical + electric` (saturating).
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+### `DataFreshness`
+
+```rust
 pub enum DataFreshness {
-    /// Données très récentes (< 2 minutes)
-    Fresh,
-    /// Données acceptables (< 5 minutes)
-    Acceptable,
-    /// Données anciennes (> 5 minutes)
-    Stale,
-    /// Données indisponibles
-    Unavailable,
+    Fresh,     // < 10 minutes
+    Recent,    // 10–30 minutes
+    Stale,     // 30–120 minutes
+    VeryStale, // > 120 minutes
 }
 ```
 
-## Schémas de Requête MCP
+### `BikeTypeFilter`
 
-### Paramètres de Recherche Géographique
 ```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct GeographicQuery {
-    /// Point central de recherche
-    pub center: Coordinates,
-    
-    /// Rayon de recherche en mètres
-    pub radius_meters: u32,
-    
-    /// Nombre maximum de résultats
-    #[serde(default = "default_limit")]
-    pub limit: u16,
-}
-
-fn default_limit() -> u16 { 50 }
-```
-
-### Filtres de Disponibilité
-```rust
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct AvailabilityFilter {
-    /// Minimum de vélos disponibles requis
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_bikes: Option<u16>,
-    
-    /// Minimum d'emplacements libres requis
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_docks: Option<u16>,
-    
-    /// Type de vélos requis
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bike_type: Option<BikeTypeFilter>,
-    
-    /// Exclure les stations hors service
-    #[serde(default = "default_true")]
-    pub exclude_out_of_service: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum BikeTypeFilter {
-    /// Au moins un vélo mécanique
-    MechanicalRequired,
-    /// Au moins un vélo électrique
-    ElectricRequired,
-    /// Vélos mécaniques ET électriques
-    BothRequired,
-    /// Vélos mécaniques OU électriques
-    AnyType,
-}
-
-fn default_true() -> bool { true }
-```
-
-### Requête Complète
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct StationQuery {
-    /// Contraintes géographiques
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub geographic: Option<GeographicQuery>,
-    
-    /// Filtres de disponibilité
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub availability: Option<AvailabilityFilter>,
-    
-    /// Codes de stations spécifiques
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub station_codes: Option<Vec<String>>,
-    
-    /// Inclure les données temps réel
-    #[serde(default = "default_true")]
-    pub include_real_time: bool,
+    #[serde(rename = "mechanical")] MechanicalOnly,
+    #[serde(rename = "electric")]   ElectricOnly,
+    #[serde(rename = "any")]        AnyType,  // default
 }
 ```
 
-## Schémas de Réponse MCP
+## Station Types
 
-### Réponse de Liste de Stations
+### `StationReference`
+
 ```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct StationListResponse {
-    /// Stations correspondant aux critères
-    pub stations: Vec<VelibStation>,
-    
-    /// Nombre total de stations trouvées
-    pub total_count: usize,
-    
-    /// Pagination si applicable
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pagination: Option<PaginationInfo>,
-    
-    /// Métadonnées de la requête
-    pub metadata: ResponseMetadata,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct PaginationInfo {
-    pub offset: usize,
-    pub limit: usize,
-    pub has_more: bool,
+pub struct StationReference {
+    pub station_code: String,
+    pub name: String,
+    pub coordinates: Coordinates,
+    pub capacity: u16,          // validated: 1–200
+    pub capabilities: ServiceCapabilities,
 }
 ```
 
-### Métadonnées de Réponse
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ResponseMetadata {
-    /// Horodatage de la réponse
-    pub response_time: DateTime<Utc>,
-    
-    /// Durée de traitement en millisecondes
-    pub processing_time_ms: u64,
-    
-    /// Source des données temps réel
-    pub real_time_source: DataSource,
-    
-    /// Source des données de référence
-    pub reference_source: DataSource,
-}
+### `RealTimeStatus`
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+```rust
+pub struct RealTimeStatus {
+    pub bikes: BikeAvailability,
+    pub available_docks: u16,
+    pub status: StationStatus,
+    pub last_update: DateTime<Utc>,
+    pub data_freshness: DataFreshness,  // derived from last_update age
+}
+```
+
+### `VelibStation`
+
+```rust
+pub struct VelibStation {
+    pub reference: StationReference,
+    pub real_time: Option<RealTimeStatus>,
+}
+```
+
+Validation invariant: `bikes.total() + available_docks ≤ capacity`.
+
+## Query / Response Types
+
+### `DataSource`
+
+```rust
 pub enum DataSource {
-    /// Données fraîches de l'API
-    Live,
-    /// Données du cache local
-    Cached { age_seconds: u64 },
-    /// Données de sauvegarde
-    Fallback,
-    /// Données indisponibles
-    Unavailable,
+    #[serde(rename = "paris_open_data")] ParisOpenData,
+    #[serde(rename = "cache")]           Cache,
+    #[serde(rename = "fallback")]        Fallback,
 }
 ```
 
-## Validation et Contraintes
+## Example JSON
 
-### Contraintes de Cohérence
-```rust
-impl VelibStation {
-    /// Valide la cohérence des données de la station
-    pub fn validate(&self) -> Result<(), ValidationError> {
-        // Vérifier la cohérence des compteurs
-        if let Some(rt) = &self.real_time {
-            let total_bikes = rt.bikes.total();
-            let expected_docks = self.reference.capacity
-                .checked_sub(total_bikes)
-                .ok_or(ValidationError::CapacityOverflow)?;
-                
-            if rt.available_docks != expected_docks {
-                return Err(ValidationError::DockCountMismatch);
-            }
-        }
-        
-        // Validation des coordonnées (Paris métropole)
-        let coords = &self.reference.coordinates;
-        if coords.latitude < 48.7 || coords.latitude > 49.0 ||
-           coords.longitude < 2.0 || coords.longitude > 2.6 {
-            return Err(ValidationError::InvalidCoordinates);
-        }
-        
-        Ok(())
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ValidationError {
-    #[error("La capacité de la station est dépassée")]
-    CapacityOverflow,
-    
-    #[error("Incohérence entre vélos et emplacements disponibles")]
-    DockCountMismatch,
-    
-    #[error("Coordonnées hors de la zone de service")]
-    InvalidCoordinates,
-}
-```
-
-## Sérialisation JSON
-
-### Exemple de Station Complète
 ```json
 {
-  "station_code": "32017",
-  "name": "Rouget de L'isle - Watteau",
-  "coordinates": {
-    "latitude": 48.936268,
-    "longitude": 2.358866
-  },
-  "capacity": 22,
-  "commune": "Issy-les-Moulineaux",
-  "insee_code": "92040",
-  "real_time": {
+  "reference": {
     "station_code": "32017",
-    "bikes": {
-      "mechanical": 8,
-      "electric": 4
-    },
-    "available_docks": 10,
-    "service": {
-      "renting_enabled": true,
-      "returning_enabled": true,
-      "installed": true
-    },
-    "status": "Operational",
-    "last_updated": "2025-06-14T19:31:22Z",
-    "valid_until": "2025-06-14T19:33:22Z"
+    "name": "Rouget de L'isle - Watteau",
+    "coordinates": { "latitude": 48.936268, "longitude": 2.358866 },
+    "capacity": 22,
+    "capabilities": {
+      "accepts_credit_card": true,
+      "has_charging_station": false,
+      "is_virtual_station": false
+    }
   },
-  "data_freshness": "Fresh"
+  "real_time": {
+    "bikes": { "mechanical": 8, "electric": 4 },
+    "available_docks": 10,
+    "status": "OPEN",
+    "last_update": "2025-06-14T19:31:22Z",
+    "data_freshness": "Fresh"
+  }
 }
 ```

--- a/docs/context/etat_actuel.md
+++ b/docs/context/etat_actuel.md
@@ -1,41 +1,19 @@
-# État Actuel du Projet Velib MCP
+# Project Status
 
-## Phase Actuelle: Phase 2 - Architecture Système
+All implementation phases are complete. The server is deployed and operational.
 
-### Statut: Prêt à commencer
-Date de dernière mise à jour: 2025-06-14
+## Completed Phases
 
-## Phase 0 - Configuration (TERMINÉE ✅)
-- ✅ Initialisation du projet Rust avec cargo
-- ✅ Configuration git et remote GitHub (DominicBurkart/velib-mcp)
-- ✅ Structure de documentation créée (/docs)
-- ✅ Configuration des hooks pre-commit (fmt, clippy, audit)
-- ✅ Workflow CI/CD GitHub Actions configuré
-- ✅ Dockerfile créé pour déploiement Scaleway (compatible Podman)
-- ✅ Système de suivi de contexte Claude initialisé
-- ✅ Documentation projet et README créés
+- **Phase 0**: Project setup — Rust project init, GitHub remote, CI/CD, pre-commit hooks, Dockerfile
+- **Phase 1**: Data analysis — both datasets documented, Rust schemas drafted (`docs/api/`)
+- **Phase 2A**: Environment config and base server foundation
+- **Phase 2B**: MCP protocol foundation and core types
+- **Phase 3A**: Live data API integration and data client
+- **Phase 3B**: Full MCP handlers with live data integration
+- **Phase 4**: Repository cleanup (removal of committed worktrees)
 
-## Phase 1 - Analyse des Données (TERMINÉE ✅)
-- ✅ Analyse complète du dataset disponibilité temps réel
-- ✅ Analyse complète du dataset emplacements des stations
-- ✅ Identification structure données et colonnes (15+ champs)
-- ✅ Documentation technique détaillée (/docs/api/data_analysis.md)
-- ✅ Schémas de données Rust complets (/docs/api/mcp_schemas.md)
-- ✅ Spécification interfaces MCP avec 5 tools (/docs/api/mcp_interface_spec.md)
+## Key Files
 
-## Prochaines Étapes (Phase 2)
-1. 🎯 Architecturer le système et composants
-2. 🎯 Définir l'organisation modulaire du code Rust
-3. 🎯 Planifier l'approche agile avec PRs cohérentes
-4. 🎯 Documenter l'architecture dans /docs/decisions
-
-## Dépendances Techniques
-- Rust (version stable récente)
-- GitHub Actions pour CI/CD
-- Scaleway CLI pour déploiement
-- Podman pour conteneurisation
-
-## Notes Importantes
-- Repository configuré pour github.com/dominicburkart/velib-mcp
-- Email configuré: dominic@dominic.computer
-- Approche TDD requise pour toutes les fonctionnalités
+- `src/types.rs` — canonical data structures
+- `docs/api/data_analysis.md` — upstream API field documentation
+- `docs/api/mcp_interface_spec.md` — MCP tool/resource specifications


### PR DESCRIPTION
## Summary

- **README.md**: Collapsed 6 badges to 3 (removed duplicate CI links and misleading static "security passing" badge); fixed Quick Start (`cargo run` command replaced with just `velib-mcp`); replaced repetitive collapsible integration section (4× identical `cargo install` lines) with a single generic JSON config snippet; removed Architecture section that duplicated Deployment; tools list converted to a table with a pointer to the spec doc.
- **CLAUDE.md**: Removed the ~120-line "Processus de Développement Multi-Agents" block (fabricated performance metrics, internal process templates not useful to contributors or AI coding assistants); removed duplicated worktree structure diagram; condensed completed-phases list that was already tracked in `docs/context/etat_actuel.md`.
- **docs/context/etat_actuel.md**: Rewrote in English to match the rest of the repo; removed stale "Phase 2 - Prêt à commencer" status (project is complete); replaced hardcoded date with a stable summary.
- **docs/api/data_analysis.md**: Translated to English; tightened prose; replaced inline "Recommandations" section (duplicated schema content already in `mcp_schemas.md`) with a short update-strategy note.
- **docs/api/mcp_interface_spec.md**: Translated all French field descriptions and section headers to English; compacted redundant whitespace in JSON schemas; merged health resource into the Resources section; error types reformatted as a table.
- **docs/api/mcp_schemas.md**: Translated to English; replaced divergent type definitions (wrong enum variants, extra fields not in code) with types that exactly match `src/types.rs`; added pointer to canonical Rust source at top.

## Test plan

- [ ] Verify README renders correctly on GitHub (badges, code blocks, table)
- [ ] Confirm CLAUDE.md retains all information an AI coding assistant needs (commands, layout, deployment target)
- [ ] Check that `mcp_schemas.md` enum variants (`OPEN`/`CLOSED`/`MAINTENANCE`, `Fresh`/`Recent`/`Stale`/`VeryStale`) match `src/types.rs`
- [ ] Confirm no source code files were changed