### PR TITLE
arch: replace expect() with ? and add tracing default level

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,16 @@ use velib_mcp::{parse_server_address, Server};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing
+    // Initialize tracing with a sensible default if RUST_LOG is not set
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
         .init();
 
     // Parse server address from environment variables
-    let addr = parse_server_address()
-        .expect("Failed to parse server address from IP and PORT environment variables");
+    let addr = parse_server_address()?;
 
     // Create and run server
     let server = Server::new(addr);


### PR DESCRIPTION
Two minimal architectural improvements to `src/main.rs`:\n\n1. **Replace `.expect()` with `?`** — `parse_server_address()` already returns a `Result`, and `main()` already declares `Result<_, Box<dyn std::error::Error>>`. Using `.expect()` panics instead of propagating the error cleanly through the declared return type. Replaced with `?` so the caller gets a proper error message.\n\n2. **Add a default tracing level** — `EnvFilter::from_default_env()` silently produces no log output when `RUST_LOG` is unset. Switched to `try_from_default_env()` with a fallback of `\"info\"` so the server emits useful logs out of the box without requiring the operator to know to set `RUST_LOG`.