### PR TITLE
feat: add cargo-deny pre-commit hook (#88)

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -4,4 +4,4 @@ cargo clippy --fix --all-features --all-targets --allow-dirty --allow-staged
 cargo fmt --all
 cargo sort
 git add Cargo.toml
-cargo deny check
+cargo deny check licenses bans sources

--- a/README.md
+++ b/README.md
@@ -114,7 +114,23 @@ cargo test
 cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo audit
+cargo deny check licenses bans sources
 ```
+
+### Pre-commit hooks
+
+`cargo-husky` is installed as a dev-dependency and automatically installs a Git
+pre-commit hook the first time `cargo test` (or any cargo command that builds
+dev-dependencies) runs. The hook lives at `.cargo-husky/hooks/pre-commit` and
+enforces:
+
+- `cargo clippy --fix --all-features --all-targets`
+- `cargo fmt --all`
+- `cargo sort`
+- `cargo deny check licenses bans sources` (mirrors the `license-compliance` CI
+  job so license, bans, and source-provenance regressions are caught locally)
+
+Any non-zero exit aborts the commit.
 
 ### Podman
 


### PR DESCRIPTION
## Summary

Narrows the existing `cargo deny check` invocation in the cargo-husky
`pre-commit` hook to `cargo deny check licenses bans sources`, aligning
it with the `license-compliance` CI job introduced in #45. This finishes
the pre-commit hook work that was deferred from #29 when #45 focused on
CI.

- `.cargo-husky/hooks/pre-commit`: `cargo deny check` -> `cargo deny check licenses bans sources`
- `README.md`: documents the hook in the Development section so
  contributors know what the pre-commit gate enforces.
- `deny.toml` is intentionally untouched.

The hook uses `set -e`, so any non-zero exit from `cargo deny` aborts
the commit.

Closes #88
Closes #29

## Feedback loops

- Manual hook simulation: `bash .cargo-husky/hooks/pre-commit` locally.
- CI: the `license-compliance` job (added by #45) exercises the same
  scope on every push/PR.

## Pre-push check status (run from the CRON worker)

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- `cargo test --workspace --all-features` — pass
- `cargo deny check licenses bans sources` — **fails on `main`'s current
  `deny.toml`** (rejects the `Unicode-3.0` SPDX expression introduced by
  recent `icu_*` / `tinystr` dependency bumps, plus warns on three
  unmatched allow entries). This is a pre-existing repo-state issue
  unrelated to this change; PR #45 already updates `deny.toml` to allow
  `Unicode-3.0` et al. Per the CRON instructions `deny.toml` is not
  modified here, so this check is **deferred to CI** (it will pass once
  #45 — or an equivalent `deny.toml` update — lands on `main`).

## Follow-ups

- Land #45 (or a rebased equivalent) so the hook's `cargo deny check
  licenses bans sources` stops red-lining locally on `main`.
- Consider moving the heavy `clippy --fix` step out of the pre-commit
  path if commit latency becomes a pain point now that an additional
  network-touching `cargo deny` check runs on every commit.

<!-- JOB-ID: CRON-20260418 -->
<!-- OLDEST-ISSUE: DominicBurkart/velib-mcp#88 -->