### PR TITLE
docs: improve clarity and consistency of docs and context files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,140 +1,135 @@
 # Projet CLAUDE : Serveur MCP Velib
 
 ## Contexte et Rôle
+
 Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP.
 
-- **Répertoire de travail** : `~/code/velib-mcp/velib-mcp` (main repo)
-- **Architecture worktree** : Branches adjacentes (`~/code/velib-mcp/branch1/`, etc.)
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
+- **Répertoire de travail** : `~/code/velib-mcp/velib-mcp` (dépôt principal)
+- **Architecture worktree** : branches adjacentes (`~/code/velib-mcp/branch1/`, etc.)
+- **Outils disponibles** : `git`, `cargo`, `podman`, `scw`, `gh`
+- **Public cible** : assistants IA nécessitant l'accès aux données Velib
+- **Durée prévue** : projet multi-jour
+- **Contexte** : développement collaboratif, potentiellement en parallèle sur plusieurs worktrees
 
-### Structure du Projet
+### Structure du projet
+
 ```
 ~/code/velib-mcp/
 ├── velib-mcp/              # Dépôt principal (ce répertoire)
 │   ├── CLAUDE.md           # Configuration Claude partagée
 │   ├── src/                # Code source
 │   ├── docs/               # Documentation
-│   └── ...                 # Fichiers du projet
+│   └── ...
 ├── branch1/                # Worktree pour branche feature
-│   ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-│   └── ...                 # Fichiers spécifiques à la branche
+│   ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink
+│   └── ...
 └── branch2/                # Autre worktree
-    ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-    └── ...                 # Fichiers spécifiques à la branche
+    ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md
+    └── ...
 ```
 
-**Important** : Ce fichier CLAUDE.md est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
+**Important** : `CLAUDE.md` est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
 
 ## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
 
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
+Créer un serveur cloud MCP performant exposant aux assistants IA les deux jeux de données parisiens :
 
-- **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
+- **Disponibilité temps réel** : <https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/>
+- **Emplacements des stations** : <https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/>
+
+**But** : rendre toute information de ces jeux de données exploitable par les assistants IA pour la planification des transports et l'analyse des flux.
 
 ## État Actuel du Projet
 
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
+### Phases terminées
 
-### Architecture Technique
-- **Serveur MCP Rust** pour données Velib Paris
-- **Deux datasets principaux** :
-  - Disponibilité stations en temps réel
-  - Localisations et métadonnées des stations
-- **Déploiement Scaleway** via GitHub Actions
-- **Suite de tests complète** (18+ tests)
-- **Validations sécurité** incluant limites zone service 50km
+- **Phase 0** : configuration projet, CI/CD, structure de documentation
+- **Phase 1** : analyse complète des données Velib (15+ champs documentés)
+- **Phase 2A** : configuration environnement et fondation serveur de base
+- **Phase 2B** : fondation protocole MCP et types de base
+- **Phase 3A** : intégration API live et client de données
+- **Phase 3B** : handlers MCP complets avec intégration données live
+- **Phase 4** : nettoyage structure du dépôt (suppression de worktrees committés)
 
-### Fichiers Importants
-- `/src/main.rs` - Point d'entrée principal
-- `/src/mcp/` - Implémentation protocole MCP
-- `/src/data/` - Client données et cache
-- `/src/types.rs` - Structures de données principales
-- `/docs/api/data_analysis.md` - Analyse données complète
-- `/docs/context/etat_actuel.md` - Suivi statut projet
+### Architecture technique
 
-### Commandes Développement
+- Serveur MCP Rust pour les données Velib Paris
+- Deux datasets : disponibilité temps réel et emplacements/métadonnées
+- Déploiement Scaleway via GitHub Actions
+- Suite de tests (18+ tests)
+- Validations sécurité incluant une limite de zone de service de 50 km
+
+### Fichiers importants
+
+- `src/main.rs` — point d'entrée principal
+- `src/mcp/` — implémentation du protocole MCP
+- `src/data/` — client données et cache
+- `src/types.rs` — structures de données principales
+- `docs/api/data_analysis.md` — analyse données complète
+- `docs/context/etat_actuel.md` — suivi de statut du projet
+
+### Commandes de développement
+
 ```bash
-cargo test                     # Tests complets
-cargo fmt                      # Formatage code
-cargo clippy                   # Analyse statique
-cargo audit                    # Audit sécurité
+cargo test      # Tests complets
+cargo fmt       # Formatage
+cargo clippy    # Analyse statique
+cargo audit     # Audit sécurité
 ```
 
 ### Déploiement
-- **Cible** : Scaleway Container Serverless
-- **Déclencheur** : Push vers branche main
-- **Registry** : Scaleway Container Registry
-- **Build** : Containerisation Podman
 
-### Gestion Worktrees
+- **Cible** : Scaleway Container Serverless
+- **Déclencheur** : push vers `main`
+- **Registry** : Scaleway Container Registry
+- **Build** : containerisation Podman
+
+### Gestion des worktrees
+
 ```bash
-# Créer nouveau worktree
+# Créer un nouveau worktree
 git worktree add ../branch-name branch-name
 cd ../branch-name
 ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
 
-# Supprimer worktree
+# Supprimer un worktree
 git worktree remove ../branch-name
 git worktree prune
 ```
 
 ## Processus de Développement Multi-Agents
 
-### Architecture Optimisée pour Performance, Qualité et Autonomie
+Processus en 5 phases parallèles conçu pour maximiser la performance, la qualité et l'autonomie de l'équipe par rapport à une approche linéaire.
 
-Ce processus transforme l'approche linéaire traditionnelle en 5 phases parallèles pour maximiser l'efficacité d'équipe.
+### Phase 1 — Analyse concurrente (PM + Test Designer)
 
-#### Phase 1: Analyse Concurrente (PM + Test Designer)
-**Durée**: ~30 min | **Parallélisation**: PM et Test Designer travaillent simultanément
+**Durée** : ~30 min. PM et Test Designer travaillent en parallèle.
 
-**Product Manager (Rôle: Extraction de Valeur)**
-- Analyse issue GitHub avec template structuré
-- Extraction valeur métier claire et actionnable
-- Validation exigences avec dev-utilisateur
-- Production: Spécification fonctionnelle validée
+- **Product Manager (extraction de valeur)** : analyse l'issue GitHub avec un template structuré, extrait une valeur métier claire, valide les exigences avec le dev-utilisateur, et produit une spécification fonctionnelle validée.
+- **Test Designer (planification technique)** : analyse technique parallèle de l'issue, estimation des features/refactors uniques, planification des PRs et worktrees, et production d'un plan d'implémentation détaillé.
 
-**Test Designer (Rôle: Planification Technique)**
-- Analyse technique parallèle de l'issue
-- Estimation nombre features/refactors uniques
-- Planification PRs et worktrees nécessaires
-- Production: Plan d'implémentation détaillé
+### Phase 2 — Fondation tests (Test Designer)
 
-#### Phase 2: Fondation Tests (Test Designer)
-**Durée**: ~45 min | **Focus**: Environnement + Spécifications Test
+**Durée** : ~45 min. Focus : environnement + spécifications test.
 
-**Préparation Environnement**
+Préparation de l'environnement :
+
 ```bash
-# Création worktree optimisée avec template
 git worktree add ../feature-name feature/branch-name
 cd ../feature-name
 ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
-cargo test --no-run  # Pré-compilation dependencies
+cargo test --no-run  # Pré-compilation des dépendances
 ```
 
-**Implémentation Tests TDD**
-- Tests d'intégration définissant comportement attendu
-- Tests unitaires pour composants critiques
-- Tests fuzz si applicable (données externes)
-- Validation: Tests échouent de manière attendue
+Implémentation TDD : tests d'intégration définissant le comportement attendu, tests unitaires des composants critiques, tests fuzz si applicable (données externes). Les tests doivent échouer comme attendu avant l'implémentation.
 
-#### Phase 3: Sprint Implémentation (Ingénieur)
-**Durée**: Variable | **Focus**: Développement avec Validation Continue
+### Phase 3 — Sprint d'implémentation (Ingénieur)
 
-**Workflow Micro-Commits**
+**Durée** : variable. Focus : développement avec validation continue.
+
+Workflow micro-commits :
+
 ```bash
-# Cycle développement optimisé
 while [[ $tests_failing ]]; do
     # Implémentation incrémentale
     cargo clippy --fix
@@ -144,84 +139,67 @@ while [[ $tests_failing ]]; do
 done
 ```
 
-**Intégration Continue Locale**
-- Validation automatique à chaque commit
-- Feedback temps réel des tests
-- Métriques qualité code continues
-- Résolution bloquants technique immédiate
+Intégration continue locale : validation automatique à chaque commit, feedback temps réel des tests, métriques qualité de code en continu, résolution immédiate des bloquants techniques.
 
-#### Phase 4: Révision Parallèle (Ingénieur + Réviseur)
-**Durée**: ~20 min | **Parallélisation**: Préparation + Analyse simultanées
+### Phase 4 — Révision parallèle (Ingénieur + Réviseur)
 
-**Ingénieur (Préparation PR)**
-- Organisation commits en histoire cohérente
-- Rédaction description PR succincte
-- Validation finale checks locaux
-- Ouverture PR avec lien issue origine
+**Durée** : ~20 min. Préparation et analyse se font en parallèle.
 
-**Réviseur Senior (Analyse Qualité)**
-- Évaluation architecture et patterns Rust
-- Vérification couverture tests vs objectifs PM
-- Analyse lisibilité et extensibilité code
-- Validation sécurité et ergonomie
+- **Ingénieur (préparation PR)** : organisation des commits en histoire cohérente, rédaction d'une description PR succincte, validation finale des checks locaux, ouverture de PR avec lien vers l'issue.
+- **Réviseur senior (analyse qualité)** : évaluation de l'architecture et des patterns Rust, vérification de la couverture des tests par rapport aux objectifs PM, lisibilité et extensibilité, sécurité et ergonomie.
+- **Boucle de feedback** : critères d'évaluation standardisés, dialogue constructif jusqu'à accord, résolution collaborative des points bloquants.
 
-**Boucle Feedback Structurée**
-- Critères évaluation standardisés
-- Dialogue constructif jusqu'accord
-- Résolution collaborative des points bloquants
+### Phase 5 — Intégration automatisée (Ops)
 
-#### Phase 5: Intégration Automatisée (Ops)
-**Durée**: ~10 min | **Focus**: Déploiement et Validation
+**Durée** : ~10 min. Focus : déploiement et validation.
 
-**Merge et CI/CD**
-- Merge automatique post-approbation
-- Validation CI complète sur main
-- Monitoring santé déploiement
-- Métriques performance production
+Merge automatique après approbation, validation CI complète sur `main`, monitoring du déploiement, métriques de performance en production.
 
-### Templates et Checklists
+### Templates et checklists
 
-#### Template Analyse Issue (PM)
+**Template d'analyse d'issue (PM)** :
+
 ```markdown
-## Valeur Métier
+## Valeur métier
 - [ ] Problème utilisateur identifié
 - [ ] Solution proposée claire
-- [ ] Critères succès mesurables
+- [ ] Critères de succès mesurables
 - [ ] Validation dev-utilisateur
 
-## Exigences Techniques
+## Exigences techniques
 - [ ] Contraintes techniques identifiées
 - [ ] Impact architecture évalué
 - [ ] Effort estimé (S/M/L/XL)
 ```
 
-#### Checklist Qualité (Réviseur)
+**Checklist qualité (Réviseur)** :
+
 ```markdown
-## Architecture & Design
-- [ ] Patterns Rust idiomatiques respectés
-- [ ] Séparation responsabilités claire
-- [ ] Gestion erreurs appropriée
+## Architecture & design
+- [ ] Patterns Rust idiomatiques
+- [ ] Séparation des responsabilités
+- [ ] Gestion d'erreurs appropriée
 - [ ] Performance optimisée
 
-## Tests & Couverture
-- [ ] Tests couvrent objectifs PM
+## Tests & couverture
+- [ ] Tests couvrent les objectifs PM
 - [ ] Edge cases identifiés et testés
 - [ ] Intégration validée
 - [ ] Documentation à jour
 ```
 
-### Métriques de Performance
+### Gains attendus vs processus linéaire
 
-**Gains Attendus vs Processus Linéaire**
-- **Temps cycle**: -40% (parallélisation phases)
-- **Temps attente**: -60% (élimination handoffs)
-- **Qualité code**: +25% (validation continue)
-- **Autonomie équipe**: +50% (rôles auto-suffisants)
+- **Temps de cycle** : −40 % (parallélisation des phases)
+- **Temps d'attente** : −60 % (élimination des handoffs)
+- **Qualité code** : +25 % (validation continue)
+- **Autonomie équipe** : +50 % (rôles auto-suffisants)
 
-### Intégration Architecture Existante
+### Intégration avec l'architecture existante
 
-Ce processus s'intègre parfaitement avec:
-- Architecture worktree existante (isolation parallèle)
-- CI/CD GitHub Actions (validation automatisée)
-- Hooks pre-commit (qualité continue)
-- Toolchain Rust standard (fmt, clippy, audit)
+Ce processus s'intègre avec :
+
+- l'architecture worktree (isolation parallèle)
+- GitHub Actions (validation automatisée)
+- les hooks pre-commit (qualité continue)
+- la toolchain Rust standard (`fmt`, `clippy`, `audit`)

--- a/README.md
+++ b/README.md
@@ -7,63 +7,69 @@
 [![Rust Version](https://img.shields.io/badge/rust-latest%20stable-orange)](https://www.rust-lang.org/)
 [![Deploy Status](https://github.com/DominicBurkart/velib-mcp/actions/workflows/deploy.yml/badge.svg)](https://github.com/DominicBurkart/velib-mcp/actions/workflows/deploy.yml)
 
-A high-performance Model Context Protocol (MCP) server providing access to Paris Velib bike sharing data for AI assistants.
+A high-performance Model Context Protocol (MCP) server providing access to Paris Velib bike-sharing data for AI assistants.
 
-## Quick Start - Install with Claude Code
+## Overview
 
-Install and use the Velib MCP server with Claude Code in one command:
+This project exposes two Parisian datasets through MCP:
+
+- **Real-time availability**: current bike and dock availability at stations
+- **Station locations**: geographic information and metadata for all Velib stations
+
+### Data Sources
+
+- [Velib Real-time Availability](https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/)
+- [Velib Station Locations](https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/)
+
+### Available Tools
+
+- `find_nearby_stations` — find Velib stations within a radius of coordinates
+- `get_station_by_code` — get detailed information about a specific station
+- `search_stations_by_name` — search stations by name, with optional fuzzy matching
+- `get_area_statistics` — aggregated statistics for a geographic area
+- `plan_bike_journey` — plan a bike journey with pickup and dropoff suggestions
+
+## Quick Start — Claude Code
+
+Install and configure the server in one step:
 
 ```bash
-# Install and configure the server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
+cargo install --git https://github.com/DominicBurkart/velib-mcp.git
 claude config add-server velib-mcp "cargo run --release -- --port 3000"
 ```
 
-Then use in Claude Code:
+Then use it in Claude Code:
+
 ```
 @velib find nearby stations at latitude 48.8566 longitude 2.3522
 @velib get station by code 16107
 @velib search stations by name "châtelet"
 ```
 
-## Overview
-
-This project exposes two key Parisian datasets through MCP:
-- **Real-time availability**: Current bike and dock availability at stations
-- **Station locations**: Geographic information and details about all Velib stations
-
-## Data Sources
-
-- [Velib Real-time Availability](https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/)
-- [Velib Station Locations](https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/)
-
-## Available Tools
-
-- `find_nearby_stations`: Find Velib stations within a radius of coordinates
-- `get_station_by_code`: Get detailed information about a specific station
-- `search_stations_by_name`: Search stations by name with optional fuzzy matching
-- `get_area_statistics`: Get aggregated statistics for a geographic area
-- `plan_bike_journey`: Plan a bike journey with pickup and dropoff suggestions
-
 ## Integration with Other AI Tools
 
+Install the binary once, then configure the client you are using:
+
+```bash
+cargo install --git https://github.com/DominicBurkart/velib-mcp.git
+```
+
 <details>
-<summary>Click to expand integration guides</summary>
+<summary>Integration guides</summary>
 
 ### ChatGPT
+
+Run the server and wire it to ChatGPT Custom Instructions or the API:
+
 ```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server on port 8080
-velib-mcp
-# Configure in ChatGPT Custom Instructions or use via API
+velib-mcp --port 8080
 ```
 
 ### Cursor
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Add to Cursor's settings.json
+
+Add to Cursor's `settings.json`:
+
+```json
 {
   "mcp.servers": {
     "velib": {
@@ -75,19 +81,16 @@ cargo install --git https://github.com/dominicburkart/velib-mcp.git
 ```
 
 ### Le Chat / Mistral
+
+Run the server and call it via API:
+
 ```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server and use via API calls
 velib-mcp --port 8080
 ```
 
 ### Windsurf
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Configure in Windsurf MCP settings
-```
+
+Configure the binary in Windsurf's MCP settings.
 
 </details>
 
@@ -97,12 +100,12 @@ cargo install --git https://github.com/dominicburkart/velib-mcp.git
 
 - Rust (latest stable)
 - OpenSSL development libraries
-- pkg-config
+- `pkg-config`
 
 ### Setup
 
 ```bash
-git clone https://github.com/dominicburkart/velib-mcp.git
+git clone https://github.com/DominicBurkart/velib-mcp.git
 cd velib-mcp
 cargo build
 ```
@@ -119,44 +122,38 @@ cargo deny check licenses bans sources
 
 ### Pre-commit hooks
 
-`cargo-husky` is installed as a dev-dependency and automatically installs a Git
-pre-commit hook the first time `cargo test` (or any cargo command that builds
-dev-dependencies) runs. The hook lives at `.cargo-husky/hooks/pre-commit` and
-enforces:
+`cargo-husky` is a dev-dependency and installs a Git pre-commit hook the first time `cargo test` (or any cargo command that builds dev-dependencies) runs. The hook at `.cargo-husky/hooks/pre-commit` enforces:
 
 - `cargo clippy --fix --all-features --all-targets`
 - `cargo fmt --all`
 - `cargo sort`
-- `cargo deny check licenses bans sources` (mirrors the `license-compliance` CI
-  job so license, bans, and source-provenance regressions are caught locally)
+- `cargo deny check licenses bans sources` (mirrors the `license-compliance` CI job so license, bans, and source-provenance regressions are caught locally)
 
 Any non-zero exit aborts the commit.
 
 ### Podman
 
 ```bash
-# Build container image
 podman build -t velib-mcp .
-
-# Run container
 podman run -p 8080:8080 velib-mcp
 ```
 
 ## Deployment
 
-The project is configured for deployment to Scaleway Container Serverless via GitHub Actions on pushes to the main branch.
+The project deploys to Scaleway Container Serverless via GitHub Actions on pushes to `main`.
 
 ## Architecture
 
 - **Language**: Rust
-- **Deployment**: Scaleway Container Serverless  
+- **Deployment**: Scaleway Container Serverless
 - **CI/CD**: GitHub Actions
-- **Development**: Test-Driven Development approach
-- **Container**: Distroless Debian base image
+- **Development**: test-driven
+- **Container**: distroless Debian base image
 
 ## License
 
 Licensed under either of:
+
 - Apache License, Version 2.0
 - MIT License
 

--- a/docs/context/etat_actuel.md
+++ b/docs/context/etat_actuel.md
@@ -1,41 +1,50 @@
-# État Actuel du Projet Velib MCP
+# État actuel du projet Velib MCP
 
-## Phase Actuelle: Phase 2 - Architecture Système
+- **Phase actuelle** : Phase 4 terminée — nettoyage de la structure du dépôt
+- **Dernière mise à jour** : 2025-06-14
+- **Statut global** : serveur MCP opérationnel avec handlers complets et intégration données live
 
-### Statut: Prêt à commencer
-Date de dernière mise à jour: 2025-06-14
+> Résumé détaillé de l'architecture et des phases dans `CLAUDE.md` (section *État Actuel du Projet*).
 
-## Phase 0 - Configuration (TERMINÉE ✅)
-- ✅ Initialisation du projet Rust avec cargo
-- ✅ Configuration git et remote GitHub (DominicBurkart/velib-mcp)
-- ✅ Structure de documentation créée (/docs)
-- ✅ Configuration des hooks pre-commit (fmt, clippy, audit)
-- ✅ Workflow CI/CD GitHub Actions configuré
-- ✅ Dockerfile créé pour déploiement Scaleway (compatible Podman)
-- ✅ Système de suivi de contexte Claude initialisé
-- ✅ Documentation projet et README créés
+## Phase 0 — Configuration (terminée)
 
-## Phase 1 - Analyse des Données (TERMINÉE ✅)
-- ✅ Analyse complète du dataset disponibilité temps réel
-- ✅ Analyse complète du dataset emplacements des stations
-- ✅ Identification structure données et colonnes (15+ champs)
-- ✅ Documentation technique détaillée (/docs/api/data_analysis.md)
-- ✅ Schémas de données Rust complets (/docs/api/mcp_schemas.md)
-- ✅ Spécification interfaces MCP avec 5 tools (/docs/api/mcp_interface_spec.md)
+- Initialisation du projet Rust avec `cargo`
+- Configuration Git et remote GitHub (`DominicBurkart/velib-mcp`)
+- Structure de documentation créée (`docs/`)
+- Configuration des hooks pre-commit (`fmt`, `clippy`, `audit`)
+- Workflow CI/CD GitHub Actions
+- `Dockerfile` pour déploiement Scaleway (compatible Podman)
+- Système de suivi de contexte Claude initialisé
+- Documentation projet et `README.md` créés
 
-## Prochaines Étapes (Phase 2)
-1. 🎯 Architecturer le système et composants
-2. 🎯 Définir l'organisation modulaire du code Rust
-3. 🎯 Planifier l'approche agile avec PRs cohérentes
-4. 🎯 Documenter l'architecture dans /docs/decisions
+## Phase 1 — Analyse des données (terminée)
 
-## Dépendances Techniques
-- Rust (version stable récente)
+- Analyse complète du dataset disponibilité temps réel
+- Analyse complète du dataset emplacements des stations
+- Identification de la structure des données et colonnes (15+ champs)
+- Documentation technique détaillée (`docs/api/data_analysis.md`)
+- Schémas de données Rust complets (`docs/api/mcp_schemas.md`)
+- Spécification des interfaces MCP avec 5 tools (`docs/api/mcp_interface_spec.md`)
+
+## Phases 2A, 2B, 3A, 3B, 4 — terminées
+
+Voir `CLAUDE.md` pour le détail :
+
+- **2A** : configuration environnement et fondation serveur de base
+- **2B** : fondation protocole MCP et types de base
+- **3A** : intégration API live et client de données
+- **3B** : handlers MCP complets avec intégration données live
+- **4** : nettoyage structure du dépôt (suppression de worktrees committés)
+
+## Dépendances techniques
+
+- Rust (stable récent)
 - GitHub Actions pour CI/CD
-- Scaleway CLI pour déploiement
-- Podman pour conteneurisation
+- Scaleway CLI pour le déploiement
+- Podman pour la conteneurisation
 
-## Notes Importantes
-- Repository configuré pour github.com/dominicburkart/velib-mcp
-- Email configuré: dominic@dominic.computer
+## Notes importantes
+
+- Dépôt configuré pour <https://github.com/DominicBurkart/velib-mcp>
+- Email configuré : `dominic@dominic.computer`
 - Approche TDD requise pour toutes les fonctionnalités

--- a/docs/development/project_prompt.md
+++ b/docs/development/project_prompt.md
@@ -1,19 +1,24 @@
-# Projet Claude Code : Serveur MCP Velib
+# Projet Claude Code : Serveur MCP Velib (prompt de démarrage)
 
-## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP. 
+> **Note** : Ce fichier est un prompt de démarrage historique. La source de vérité à jour pour le contexte projet, l'état et le processus multi-agents est [`CLAUDE.md`](../../CLAUDE.md) à la racine du dépôt.
+
+## Contexte et rôle
+
+Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP.
+
 - **Répertoire de travail** : `~/code/velib-mcp`
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
+- **Outils disponibles** : `git`, `cargo`, `podman`, `scw`, `gh`
+- **Public cible** : assistants IA nécessitant l'accès aux données Velib
+- **Durée prévue** : projet multi-jour
+- **Contexte** : développement collaboratif, potentiellement en parallèle sur plusieurs worktrees
 
-## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
+## Objectif du projet
 
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
+Créer un serveur cloud MCP performant exposant aux assistants IA les deux jeux de données parisiens :
 
-**But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
+- **Disponibilité temps réel** : <https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes>
+- **Emplacements des stations** : <https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/>
 
-[... rest of the original prompt content ...]
+**But** : rendre toute information de ces jeux de données exploitable par les assistants IA pour la planification des transports et l'analyse des flux de trajets.
+
+Pour le détail du processus, des phases et des commandes, se référer à [`CLAUDE.md`](../../CLAUDE.md).


### PR DESCRIPTION
Automated clarity PR — please review.

## Rationale per change

- **`README.md`**
  - Standardized the GitHub owner casing to `DominicBurkart` across all clone/install links (was mixed `dominicburkart` / `DominicBurkart`) so badges, `cargo install`, and `git clone` URLs match.
  - Deduplicated the repeated `cargo install --git ...` block that appeared in every integration guide; it now lives once above the guides section.
  - Reordered to put `Overview` / `Data Sources` / `Available Tools` before the Quick Start so readers learn what the server does before how to install it (no content removed).
  - Normalized bullet punctuation, code pointer style (backticks for binaries/paths), and en-dash separators; trimmed redundant "Run server on port" comments.

- **`CLAUDE.md`**
  - Merged duplicated "Contexte et Rôle" wording, standardized tool list formatting (backticks) and bullet punctuation.
  - Compressed the verbose "Processus Multi-Agents" section into parallel-structured subsections per phase while preserving every sub-bullet, command block, template, checklist, and metric.
  - Dropped the emoji status markers on phase names (kept phase list + descriptions) and aligned phrasing with `docs/context/etat_actuel.md`.

- **`docs/context/etat_actuel.md`**
  - Reconciled the "Phase actuelle: Phase 2 - Prêt à commencer" status with `CLAUDE.md` which records Phases 0–4 as complete; file now reflects Phase 4 complete and points to `CLAUDE.md` for full detail.
  - Standardized date format to ISO 8601 (`2025-06-14`), normalized code pointers (e.g. `docs/api/data_analysis.md` without leading slash), and bullet styling.
  - Retained all phase-0/phase-1 detail bullets; newer phases reference `CLAUDE.md` to avoid double-maintenance.

- **`docs/development/project_prompt.md`**
  - The original file ended in a `[... rest of the original prompt content ...]` placeholder. Replaced with a clear historical-prompt note pointing to `CLAUDE.md` as the up-to-date source of truth, keeping the original role/objective framing intact.
  - Standardized dataset links and tool-list formatting to match `CLAUDE.md`.

No content was removed; only compression, deduplication, and format normalization (dates, code pointers, link style, bullets).