### PR TITLE
test(types): Coordinates invariants and doctests

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,22 @@ pub struct Coordinates {
 }
 
 impl Coordinates {
+    /// Create a new `Coordinates` from decimal degrees.
+    ///
+    /// `latitude` is expected in `[-90.0, 90.0]` and `longitude` in
+    /// `[-180.0, 180.0]`, but no validation is performed here; validation is
+    /// the responsibility of callers (see [`Coordinates::is_valid_paris_metro`]
+    /// and [`Coordinates::is_within_paris_service_area`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use velib_mcp::types::Coordinates;
+    ///
+    /// let city_hall = Coordinates::new(48.8565, 2.3514);
+    /// assert_eq!(city_hall.latitude, 48.8565);
+    /// assert_eq!(city_hall.longitude, 2.3514);
+    /// ```
     #[must_use]
     pub fn new(latitude: f64, longitude: f64) -> Self {
         Self {
@@ -16,7 +32,31 @@ impl Coordinates {
         }
     }
 
-    /// Calculate distance to another coordinate in meters using Haversine formula
+    /// Calculate great-circle distance to another coordinate in meters using
+    /// the Haversine formula (spherical Earth with radius 6 371 000 m).
+    ///
+    /// The result is symmetric, non-negative, and bounded above by
+    /// `π * 6_371_000 ≈ 2.0015e7` meters (antipodal distance).
+    ///
+    /// # Examples
+    ///
+    /// Distance from a point to itself is zero:
+    /// ```
+    /// use velib_mcp::types::Coordinates;
+    ///
+    /// let p = Coordinates::new(48.8566, 2.3522);
+    /// assert!(p.distance_to(&p) < 1e-6);
+    /// ```
+    ///
+    /// One degree of longitude at the equator is ~111.32 km:
+    /// ```
+    /// use velib_mcp::types::Coordinates;
+    ///
+    /// let a = Coordinates::new(0.0, 0.0);
+    /// let b = Coordinates::new(0.0, 1.0);
+    /// let d = a.distance_to(&b);
+    /// assert!((d - 111_195.0).abs() < 500.0, "got {d}");
+    /// ```
     #[must_use]
     pub fn distance_to(&self, other: &Coordinates) -> f64 {
         let earth_radius = 6_371_000.0; // Earth radius in meters
@@ -34,7 +74,20 @@ impl Coordinates {
         earth_radius * c
     }
 
-    /// Check if coordinates are within reasonable bounds for Paris metro area
+    /// Check if coordinates are within reasonable bounds for Paris metro area.
+    ///
+    /// Uses a coarse lat/lon bounding box: `48.7 ≤ lat ≤ 49.0` and
+    /// `2.0 ≤ lon ≤ 2.6`. This is a cheap pre-filter; for the authoritative
+    /// service-area check see [`Coordinates::is_within_paris_service_area`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use velib_mcp::types::Coordinates;
+    ///
+    /// assert!(Coordinates::new(48.8566, 2.3522).is_valid_paris_metro());
+    /// assert!(!Coordinates::new(40.7128, -74.0060).is_valid_paris_metro()); // NYC
+    /// ```
     #[must_use]
     pub fn is_valid_paris_metro(&self) -> bool {
         // Paris metro area bounds (approximate)
@@ -44,8 +97,19 @@ impl Coordinates {
             && self.longitude <= 2.6
     }
 
-    /// Check if coordinates are within 50km of Paris City Hall (Hôtel de Ville)
-    /// Latitude: 48.8565° N, Longitude: 2.3514° E
+    /// Check if coordinates are within 50 km of Paris City Hall
+    /// (Hôtel de Ville, 48.8565° N, 2.3514° E).
+    ///
+    /// The boundary is inclusive: a point at exactly 50 km is considered inside.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use velib_mcp::types::Coordinates;
+    ///
+    /// assert!(Coordinates::new(48.8565, 2.3514).is_within_paris_service_area());
+    /// assert!(!Coordinates::new(51.5074, -0.1278).is_within_paris_service_area()); // London
+    /// ```
     #[must_use]
     pub fn is_within_paris_service_area(&self) -> bool {
         const PARIS_CITY_HALL_LAT: f64 = 48.8565;

--- a/tests/coordinates_invariants_tests.rs
+++ b/tests/coordinates_invariants_tests.rs
@@ -1,0 +1,148 @@
+//! Randomized invariant tests for `Coordinates` great-circle distance and
+//! service-area checks.
+//!
+//! These exercise properties that should hold for every input, using
+//! `fastrand` (already a project dependency) in lieu of `proptest`. Each
+//! property runs over `CASES` random samples, which keeps the test fast
+//! while providing meaningful coverage of the input space.
+
+use velib_mcp::types::Coordinates;
+
+/// Number of random cases per invariant. Small enough to stay well under a
+/// second, large enough to catch regressions in the Haversine formula.
+const CASES: usize = 256;
+
+/// Haversine-on-sphere upper bound: half the Earth's circumference.
+/// Earth radius used by `distance_to` is 6_371_000 m, so antipodal distance
+/// is `π * R ≈ 2.0015e7 m`. We add a small numerical slack.
+const ANTIPODAL_MAX_M: f64 = std::f64::consts::PI * 6_371_000.0 + 1.0;
+
+fn random_coord(rng: &mut fastrand::Rng) -> Coordinates {
+    // Full valid lat/lon domain.
+    let lat = rng.f64() * 180.0 - 90.0;
+    let lon = rng.f64() * 360.0 - 180.0;
+    Coordinates::new(lat, lon)
+}
+
+#[test]
+fn distance_to_self_is_zero() {
+    let mut rng = fastrand::Rng::with_seed(0xC001_D00D);
+    for _ in 0..CASES {
+        let p = random_coord(&mut rng);
+        let d = p.distance_to(&p);
+        // Haversine at identity is analytically zero; float noise can produce
+        // a tiny positive value. Allow sub-millimeter tolerance.
+        assert!(
+            (0.0..1e-3).contains(&d),
+            "self-distance should be ~0, got {d} at {p:?}"
+        );
+    }
+}
+
+#[test]
+fn distance_is_symmetric() {
+    let mut rng = fastrand::Rng::with_seed(0xBEEF_F00D);
+    for _ in 0..CASES {
+        let a = random_coord(&mut rng);
+        let b = random_coord(&mut rng);
+        let ab = a.distance_to(&b);
+        let ba = b.distance_to(&a);
+        // Pure float ops are order-sensitive; allow a tiny relative error.
+        let diff = (ab - ba).abs();
+        let tolerance = (ab.abs().max(ba.abs()) * 1e-9).max(1e-6);
+        assert!(
+            diff <= tolerance,
+            "asymmetric distance: d(a,b)={ab}, d(b,a)={ba}, diff={diff}, a={a:?}, b={b:?}"
+        );
+    }
+}
+
+#[test]
+fn distance_is_non_negative_and_finite() {
+    let mut rng = fastrand::Rng::with_seed(0xDEAD_BEEF);
+    for _ in 0..CASES {
+        let a = random_coord(&mut rng);
+        let b = random_coord(&mut rng);
+        let d = a.distance_to(&b);
+        assert!(d.is_finite(), "distance must be finite, got {d}");
+        assert!(d >= 0.0, "distance must be non-negative, got {d}");
+        assert!(
+            d <= ANTIPODAL_MAX_M,
+            "distance exceeds antipodal bound: {d} > {ANTIPODAL_MAX_M}"
+        );
+    }
+}
+
+#[test]
+fn distance_is_translation_symmetric_along_equator() {
+    // On the equator, a displacement of Δlon degrees covers the same
+    // distance regardless of absolute longitude. This catches errors where
+    // latitude cosines are mishandled.
+    let mut rng = fastrand::Rng::with_seed(0xFACE_CAFE);
+    for _ in 0..CASES {
+        let lon = rng.f64() * 360.0 - 180.0;
+        let delta = rng.f64() * 10.0; // up to 10°
+                                      // Guard against wrapping past ±180° for this property.
+        if lon + delta > 180.0 {
+            continue;
+        }
+        let a = Coordinates::new(0.0, lon);
+        let b = Coordinates::new(0.0, lon + delta);
+        let a2 = Coordinates::new(0.0, 0.0);
+        let b2 = Coordinates::new(0.0, delta);
+        let d1 = a.distance_to(&b);
+        let d2 = a2.distance_to(&b2);
+        let diff = (d1 - d2).abs();
+        // Distances can be several million meters; allow mm-scale slack.
+        assert!(
+            diff < 1e-3,
+            "equatorial Δlon={delta} should be translation-invariant, got d1={d1}, d2={d2}"
+        );
+    }
+}
+
+#[test]
+fn service_area_is_consistent_with_distance_to_city_hall() {
+    // Invariant: `is_within_paris_service_area` ⇔ `distance_to(city_hall) ≤ 50 000 m`.
+    // We cover both sides of the boundary by sampling inside Europe where
+    // points can straddle the 50 km radius.
+    let city_hall = Coordinates::new(48.8565, 2.3514);
+    let mut rng = fastrand::Rng::with_seed(0x1234_5678);
+    for _ in 0..CASES {
+        // Sample broadly around Paris (roughly Western Europe) so we cover
+        // inside, near-boundary, and outside cases.
+        let lat = 45.0 + rng.f64() * 8.0; // 45..53
+        let lon = -2.0 + rng.f64() * 10.0; // -2..8
+        let p = Coordinates::new(lat, lon);
+
+        let d = p.distance_to(&city_hall);
+        let flag = p.is_within_paris_service_area();
+        let expected = d <= 50_000.0;
+        assert_eq!(
+            flag, expected,
+            "service-area flag {flag} disagrees with distance {d} m at {p:?}"
+        );
+    }
+}
+
+#[test]
+fn service_area_boundary_is_inclusive() {
+    // A point at Paris City Hall itself must be in the service area (d = 0).
+    let city_hall = Coordinates::new(48.8565, 2.3514);
+    assert!(city_hall.is_within_paris_service_area());
+    assert!(city_hall.distance_to(&city_hall) <= 50_000.0);
+}
+
+#[test]
+fn distance_known_value_paris_to_london() {
+    // Regression anchor: Paris (City Hall) ↔ London (Charing Cross) ≈ 344 km.
+    // Allow a generous band to tolerate model choice (sphere vs ellipsoid)
+    // without making this a brittle snapshot.
+    let paris = Coordinates::new(48.8565, 2.3514);
+    let london = Coordinates::new(51.5074, -0.1278);
+    let d_km = paris.distance_to(&london) / 1000.0;
+    assert!(
+        (335.0..355.0).contains(&d_km),
+        "Paris-London distance {d_km} km outside expected band"
+    );
+}

--- a/tests/coordinates_invariants_tests.rs
+++ b/tests/coordinates_invariants_tests.rs
@@ -77,17 +77,27 @@ fn distance_is_non_negative_and_finite() {
 fn distance_is_translation_symmetric_along_equator() {
     // On the equator, a displacement of Δlon degrees covers the same
     // distance regardless of absolute longitude. This catches errors where
-    // latitude cosines are mishandled.
+    // latitude cosines are mishandled. We also exercise the antimeridian
+    // wrap-around path by wrapping longitudes into [-180, 180] rather than
+    // skipping samples whose endpoint crosses ±180°.
+    fn wrap_lon(x: f64) -> f64 {
+        // Map any real value into [-180, 180] via 360° modulo.
+        let y = ((x + 180.0).rem_euclid(360.0)) - 180.0;
+        // rem_euclid on 360 yields [0, 360); subtracting 180 gives [-180, 180).
+        // Clamp the upper endpoint to handle float edge cases gracefully.
+        if y >= 180.0 {
+            y - 360.0
+        } else {
+            y
+        }
+    }
     let mut rng = fastrand::Rng::with_seed(0xFACE_CAFE);
     for _ in 0..CASES {
         let lon = rng.f64() * 360.0 - 180.0;
         let delta = rng.f64() * 10.0; // up to 10°
-                                      // Guard against wrapping past ±180° for this property.
-        if lon + delta > 180.0 {
-            continue;
-        }
+        let lon_b = wrap_lon(lon + delta);
         let a = Coordinates::new(0.0, lon);
-        let b = Coordinates::new(0.0, lon + delta);
+        let b = Coordinates::new(0.0, lon_b);
         let a2 = Coordinates::new(0.0, 0.0);
         let b2 = Coordinates::new(0.0, delta);
         let d1 = a.distance_to(&b);
@@ -96,7 +106,7 @@ fn distance_is_translation_symmetric_along_equator() {
         // Distances can be several million meters; allow mm-scale slack.
         assert!(
             diff < 1e-3,
-            "equatorial Δlon={delta} should be translation-invariant, got d1={d1}, d2={d2}"
+            "equatorial Δlon={delta} should be translation-invariant (even across the antimeridian), got d1={d1}, d2={d2}, lon={lon}, lon_b={lon_b}"
         );
     }
 }


### PR DESCRIPTION
Automated test improvement PR — please review.

## Component chosen
`Coordinates` in `src/types.rs` — the geographic primitive used across handlers (radius filtering, service-area validation, area statistics, journey planning).

## Disposition
- `distance_to`: previously had one sanity check (Paris center → Louvre).
- `is_valid_paris_metro`: one smoke test.
- `is_within_paris_service_area`: four fixed-point asserts.
- No doctests on the public surface.

## Invariants asserted
1. `d(p, p) ≈ 0` for any `p` (sub-mm tolerance).
2. `d(a, b) == d(b, a)` (float-relative tolerance).
3. `d(a, b)` is finite, non-negative, and bounded by `π · R` (antipodal).
4. On the equator, `d` is translation-invariant in longitude (catches bad `cos(lat)` handling).
5. `is_within_paris_service_area(p) ⇔ distance_to(city_hall) ≤ 50_000 m` for random European samples straddling the boundary.
6. Boundary is inclusive at City Hall itself.
7. Paris↔London regression anchor (335–355 km band).

## Strategy
- **Randomized invariants** in `tests/coordinates_invariants_tests.rs` (256 cases per property, seeded `fastrand` — already a dep; no new deps). Chosen over `proptest` to avoid adding a dependency for a small, focused test surface.
- **Doctests** on `Coordinates::{new, distance_to, is_valid_paris_metro, is_within_paris_service_area}` to make the public API self-documenting and runnable.

## Scope / non-goals
- No mocks, no HTTP, no changes to production behavior.
- Handler-level integration tests remain as-is.