### PR TITLE
ci(coverage): tarpaulin-based untested-lines ratchet (#16)

### DIFF
--- a/.github/actions/coverage-ratchet/action.yml
+++ b/.github/actions/coverage-ratchet/action.yml
@@ -1,0 +1,37 @@
+name: Coverage Ratchet
+description: >
+  Run cargo-tarpaulin on HEAD and the merge-base with a base ref, and fail
+  if HEAD has more uncovered lines than the base. Writes a GitHub Actions
+  job summary with the top-N files by uncovered lines and a suggested test
+  paradigm for each (see scripts/coverage-ratchet.sh).
+inputs:
+  base-ref:
+    description: Base ref to take merge-base against.
+    required: false
+    default: origin/main
+  top-n:
+    description: Number of files to list in the summary.
+    required: false
+    default: "5"
+  install-tarpaulin:
+    description: If true, install cargo-tarpaulin via cargo install --locked.
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Install cargo-tarpaulin
+      if: inputs.install-tarpaulin == 'true'
+      shell: bash
+      run: cargo install cargo-tarpaulin --locked
+
+    - name: Self-test the ratchet
+      shell: bash
+      run: ${{ github.action_path }}/../../../scripts/coverage-ratchet.sh --self-test
+
+    - name: Ratchet
+      shell: bash
+      env:
+        COVERAGE_BASE_REF: ${{ inputs.base-ref }}
+        COVERAGE_TOP_N: ${{ inputs.top-n }}
+      run: ${{ github.action_path }}/../../../scripts/coverage-ratchet.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA
 
 ## État Actuel du Projet
 
-### Phases Terminées ✅
+### Phases Terminées
 - **Phase 0** : Configuration projet, CI/CD, structure documentation
 - **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
 - **Phase 2A** : Configuration environnement et fondation serveur de base
@@ -70,7 +70,28 @@ cargo test                     # Tests complets
 cargo fmt                      # Formatage code
 cargo clippy                   # Analyse statique
 cargo audit                    # Audit sécurité
+scripts/coverage-ratchet.sh    # Untested-lines ratchet (~75s)
+scripts/coverage-ratchet.sh --self-test   # Fixture-only sanity check (<1s)
 ```
+
+### Ratchet de couverture (agents)
+
+Les PR sont gardées par `scripts/coverage-ratchet.sh` (workflow
+`.github/workflows/coverage-ratchet.yml`). Le ratchet **échoue uniquement si
+le nombre de lignes non-couvertes augmente** par rapport au merge-base avec
+`main` (pas un pourcentage — supprimer du code testé ne pénalise pas).
+
+Lecture d'un échec :
+
+1. Récupérer le summary du job (ou `coverage/summary.md` en local).
+2. Les fichiers sont triés par lignes non-couvertes avec les ranges exacts.
+3. Chaque fichier propose un paradigme de test (unit / integration /
+   property) via l'heuristique documentée dans
+   `docs/development/coverage-ratchet.md`.
+4. Écrire des tests sur le fichier en tête de liste d'abord — plus grand
+   impact par effort.
+
+Debug / faux-positif : voir `docs/development/coverage-ratchet.md`.
 
 ### Déploiement
 - **Cible** : Scaleway Container Serverless

--- a/README.md
+++ b/README.md
@@ -132,6 +132,45 @@ enforces:
 
 Any non-zero exit aborts the commit.
 
+### Coverage ratchet (pre-push)
+
+The repo ships with a tarpaulin-based untested-lines ratchet. It compares the
+number of uncovered lines at `HEAD` against the merge-base with `origin/main`
+and refuses pushes that *increase* the uncovered count. Tracking uncovered
+lines (not percentage) avoids false alarms when tested code is deleted.
+
+Install tarpaulin once:
+
+```bash
+cargo install cargo-tarpaulin --locked
+```
+
+Wire the hook locally (symlink, so the script stays in-repo):
+
+```bash
+ln -s ../../scripts/coverage-ratchet.sh .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+Or invoke ad-hoc:
+
+```bash
+# Full run (takes ~75s on this codebase)
+scripts/coverage-ratchet.sh
+
+# Fixture-only sanity check (runs in <1s, no cargo needed)
+scripts/coverage-ratchet.sh --self-test
+
+# Debug: show the top-N uncovered files for an existing tarpaulin JSON
+scripts/coverage-ratchet.sh --summary coverage/head/tarpaulin-report.json
+```
+
+On failure the script prints a markdown summary (mirrored to
+`$GITHUB_STEP_SUMMARY` in CI) listing the top files by uncovered lines, the
+affected line ranges, and a suggested test paradigm (unit / integration /
+property). See `docs/development/coverage-ratchet.md` for the heuristic and
+debugging tips.
+
 ### Podman
 
 ```bash

--- a/docs/development/coverage-ratchet.md
+++ b/docs/development/coverage-ratchet.md
@@ -1,0 +1,95 @@
+# Coverage Ratchet (untested-lines)
+
+This doc is agent-facing: it explains how `scripts/coverage-ratchet.sh` and
+`.github/workflows/coverage-ratchet.yml` work, how to read the output, and
+how to debug false positives.
+
+## Why untested lines, not %
+
+A percentage moves when the *denominator* changes. If you delete a block of
+well-tested code, covered lines drop but the percentage can stay flat or
+even fall. Meanwhile uncovered *line count* has a clean semantic: it is the
+number of source lines tarpaulin believes are reachable and never executed
+by the test suite.
+
+The ratchet fails only when `HEAD uncovered > base uncovered` (strict `>`).
+
+## What runs where
+
+- **Local pre-push hook** (invoked, not installed): `scripts/coverage-ratchet.sh`
+  See README for how to symlink it.
+- **CI**: `.github/workflows/coverage-ratchet.yml` runs on every PR targeting
+  `main`. Pushes to `main` only run the self-test (fixtures only), so they
+  are never blocked by coverage deltas.
+- **Composite action**: `.github/actions/coverage-ratchet/` wraps the same
+  script for reuse.
+
+## The heuristic (how suggestions are chosen)
+
+For each file in the top-N uncovered list the summary suggests a test
+paradigm. The rules are intentionally simple and live in
+`scripts/coverage-ratchet-summary.py::_heuristic`:
+
+| Pattern in path                          | Suggestion                       |
+| ---------------------------------------- | -------------------------------- |
+| `/data/`, `client`, `http`, `reqwest`, `fetch` | `integration (I/O path)`   |
+| `/server/`, `/mcp/`, `handler`, `route`, `router` | `integration (routing/protocol)` |
+| `types.rs`, `serde`, `parse`, `convert`, `decode`, `encode`, `codec` | `property (data transforms)` |
+| otherwise                                 | `unit (pure function)`          |
+
+If the heuristic mis-fires for your module, add a pattern to `_heuristic`
+and extend the self-test in `scripts/coverage-ratchet.sh`.
+
+## Reading the output
+
+```
+## Coverage Ratchet (untested lines)
+| metric | value |
+| --- | --- |
+| base (<sha>) uncovered lines | 618 |
+| HEAD uncovered lines | 625 |
+| delta | 7 |
+
+### Top files by uncovered lines at HEAD
+  205  src/mcp/server.rs  lines=34-35,41,43-45,...  suggest=integration (routing/protocol)
+  173  src/mcp/handlers.rs lines=42,49,67-68,...    suggest=integration (routing/protocol)
+   ...
+```
+
+Agent loop:
+
+1. Look at the file with the biggest uncovered count.
+2. Open the listed line ranges.
+3. Pick the suggested paradigm and write a targeted test.
+4. Re-run `scripts/coverage-ratchet.sh` locally (~75s) until delta <= 0.
+
+## Debugging false positives
+
+- **Tarpaulin reports different numbers on base vs HEAD due to build
+  caching.** The script uses `--skip-clean`, which keeps prior artifacts
+  but can miss newly-introduced modules if rebuilds fail mid-way. Try
+  `cargo clean && scripts/coverage-ratchet.sh`.
+- **Merge-base is stale.** The ratchet compares against the *merge-base*,
+  not `origin/main` directly. If you rebased, the merge-base can point at
+  an ancient commit. Refresh with `git fetch origin main`.
+- **Doctests or macro-expanded lines reported as uncovered.** Tarpaulin
+  sometimes misattributes these. Inspect the raw report at
+  `coverage/head/tarpaulin-report.json` and confirm the line is genuinely
+  an executable statement.
+- **Self-test fails but `cargo test` passes.** The self-test uses
+  fixtures and does not invoke cargo. A failure there means the parsing
+  or decision logic regressed — look at
+  `scripts/coverage-ratchet-summary.py` first.
+- **CI fails, local passes.** Usually the agent forgot to push a test
+  file, or CI has a different base SHA because `fetch-depth: 0` gives
+  the full history. Check the job summary at the bottom of the CI page.
+
+## Overrides
+
+```
+COVERAGE_BASE_REF=origin/develop scripts/coverage-ratchet.sh
+COVERAGE_TOP_N=10 scripts/coverage-ratchet.sh --summary coverage/head/tarpaulin-report.json
+```
+
+Do **not** set a fixed baseline for the whole repo (`FAIL_ON_UNCOVERED=0`
+style). This is a delta check only.

--- a/scripts/coverage-ratchet-summary.py
+++ b/scripts/coverage-ratchet-summary.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Summarize tarpaulin-report.json for the coverage ratchet.
+
+Subcommands:
+  total   <report.json>              -- print integer count of uncovered lines
+  summary <report.json> [root] [top] -- print ranked top-N uncovered files
+                                        with line ranges and a paradigm heuristic
+
+Heuristic (tuned for this Rust project; trivially extensible):
+  - path contains /data/ or client/http/reqwest/fetch -> integration (I/O path)
+  - path contains /server/ or /mcp/ or handler/route  -> integration (routing/protocol)
+  - path ends in types.rs or contains serde/parse/
+    convert/decode/encode/codec                       -> property (data transforms)
+  - otherwise                                         -> unit (pure function)
+"""
+from __future__ import annotations
+import json
+import os
+import re
+import sys
+
+
+def _fp(file_entry: dict, root_abs: str) -> str:
+    parts = list(file_entry.get("path") or [])
+    if parts and parts[0] == "/":
+        joined = "/" + "/".join(parts[1:])
+    else:
+        joined = "/".join(parts)
+    if joined.startswith(root_abs + "/"):
+        return joined[len(root_abs) + 1 :]
+    return joined.lstrip("/")
+
+
+def _uncovered_lines(file_entry: dict) -> list[int]:
+    out: list[int] = []
+    for tr in file_entry.get("traces", []):
+        line = tr.get("line")
+        cov = tr.get("stats", {}).get("Line", 0)
+        if isinstance(line, int) and isinstance(cov, int) and cov == 0:
+            out.append(line)
+    return sorted(set(out))
+
+
+def _heuristic(path: str) -> str:
+    p = path.lower()
+    if re.search(r"(^|/)data(/|$)|client|http|reqwest|fetch", p):
+        return "integration (I/O path)"
+    if re.search(r"(^|/)server(/|$)|(^|/)mcp(/|$)|handler|route|router", p):
+        return "integration (routing/protocol)"
+    if re.search(r"types\.rs$|serde|parse|convert|decode|encode|codec", p):
+        return "property (data transforms)"
+    return "unit (pure function)"
+
+
+def _ranges(lines: list[int]) -> str:
+    if not lines:
+        return ""
+    out: list[str] = []
+    start = prev = lines[0]
+    for ln in lines[1:]:
+        if ln == prev + 1:
+            prev = ln
+        else:
+            out.append(f"{start}-{prev}" if start != prev else f"{start}")
+            start = prev = ln
+    out.append(f"{start}-{prev}" if start != prev else f"{start}")
+    return ",".join(out)
+
+
+def cmd_total(report_path: str) -> int:
+    with open(report_path) as f:
+        d = json.load(f)
+    total = 0
+    for file in d.get("files", []):
+        total += len(_uncovered_lines(file))
+    print(total)
+    return 0
+
+
+def cmd_summary(report_path: str, root: str, top_n: int) -> int:
+    with open(report_path) as f:
+        d = json.load(f)
+    root_abs = os.path.abspath(root).rstrip("/")
+    per_file: dict[str, list[int]] = {}
+    total = 0
+    for file in d.get("files", []):
+        lines = _uncovered_lines(file)
+        if not lines:
+            continue
+        per_file[_fp(file, root_abs)] = lines
+        total += len(lines)
+    ranked = sorted(per_file.items(), key=lambda kv: -len(kv[1]))
+    print(f"TOTAL_UNCOVERED={total}")
+    print("---")
+    for fp, lines in ranked[:top_n]:
+        print(
+            f"{len(lines):4d}  {fp}  lines={_ranges(lines)}  "
+            f"suggest={_heuristic(fp)}"
+        )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 64
+    cmd = argv[1]
+    if cmd == "total":
+        return cmd_total(argv[2])
+    if cmd == "summary":
+        root = argv[3] if len(argv) > 3 else os.getcwd()
+        top_n = int(argv[4]) if len(argv) > 4 else 5
+        return cmd_summary(argv[2], root, top_n)
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 64
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/coverage-ratchet.sh
+++ b/scripts/coverage-ratchet.sh
@@ -37,8 +37,14 @@ summarize_json()  { python3 "$PY" summary "$1" "$ROOT" "$COVERAGE_TOP_N"; }
 run_tarpaulin() {
   local out_dir="$1"
   mkdir -p "$out_dir"
-  log "running cargo tarpaulin -> $out_dir (up to 75s)"
-  ( cd "$ROOT" && cargo tarpaulin --skip-clean --ignore-tests \
+  # Isolate build artifacts per measurement so --skip-clean (kept for speed
+  # within a single run) cannot leak compiled output from a previous HEAD/base
+  # switch into the next measurement. Each out_dir gets its own target/.
+  local target_dir="$out_dir/target"
+  mkdir -p "$target_dir"
+  log "running cargo tarpaulin -> $out_dir (CARGO_TARGET_DIR=$target_dir, up to 75s)"
+  ( cd "$ROOT" && CARGO_TARGET_DIR="$target_dir" \
+      cargo tarpaulin --skip-clean --ignore-tests \
       --out Json --output-dir "$out_dir" --timeout 120 >&2 ) || return $?
   if [[ -f "$out_dir/tarpaulin-report.json" ]]; then
     printf '%s\n' "$out_dir/tarpaulin-report.json"
@@ -52,10 +58,17 @@ ratchet() {
   local base_ref="$1"
   mkdir -p "$COVERAGE_DIR/head" "$COVERAGE_DIR/base"
   local head_json base_json merge_base head_sha head_total base_total
-  head_json=$(run_tarpaulin "$COVERAGE_DIR/head")
+  # Resolve merge-base and the current HEAD BEFORE any measurement so the
+  # stash/checkout ordering is deterministic.
   merge_base=$(git merge-base HEAD "$base_ref" 2>/dev/null || git rev-parse "$base_ref")
   head_sha=$(git rev-parse HEAD)
   log "merge-base vs $base_ref = $merge_base"
+  # Measure the BASE first: stash any WIP, switch to merge-base, run tarpaulin
+  # in its own CARGO_TARGET_DIR, then return to HEAD and measure there. This
+  # ordering guarantees the base measurement is never contaminated by build
+  # artifacts produced while on HEAD (the original bug: running tarpaulin on
+  # HEAD first and then on base with --skip-clean meant base reused HEAD's
+  # incremental build outputs).
   log "stashing and checking out $merge_base"
   git stash push -u -m "coverage-ratchet-wip" >/dev/null 2>&1 || true
   git checkout -q "$merge_base"
@@ -64,6 +77,9 @@ ratchet() {
   fi
   git checkout -q "$head_sha"
   git stash pop >/dev/null 2>&1 || true
+  if ! head_json=$(run_tarpaulin "$COVERAGE_DIR/head"); then
+    return 2
+  fi
   head_total=$(uncovered_total "$head_json")
   base_total=$(uncovered_total "$base_json")
   {

--- a/scripts/coverage-ratchet.sh
+++ b/scripts/coverage-ratchet.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# coverage-ratchet.sh
+#
+# Tarpaulin-based untested-lines ratchet. Fails if HEAD has MORE uncovered
+# lines than the merge-base (default: origin/main).
+#
+# Why lines-not-percentage: deleting tested code can raise the uncovered
+# percentage artificially; tracking absolute uncovered lines avoids that.
+#
+# Usage:
+#   scripts/coverage-ratchet.sh                  # ratchet vs origin/main merge-base
+#   scripts/coverage-ratchet.sh --base <rev>     # ratchet vs <rev>
+#   scripts/coverage-ratchet.sh --self-test      # run built-in fixtures, no cargo
+#   scripts/coverage-ratchet.sh --summary <json> # print top-N uncovered summary
+#
+# Wire as pre-push hook (invoked, not installed):
+#   ln -s ../../scripts/coverage-ratchet.sh .git/hooks/pre-push
+#
+# Env overrides:
+#   COVERAGE_BASE_REF (default: origin/main)
+#   COVERAGE_DIR      (default: <repo>/coverage)
+#   COVERAGE_TOP_N    (default: 5)
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+COVERAGE_DIR="${COVERAGE_DIR:-$ROOT/coverage}"
+COVERAGE_BASE_REF="${COVERAGE_BASE_REF:-origin/main}"
+COVERAGE_TOP_N="${COVERAGE_TOP_N:-5}"
+PY="$ROOT/scripts/coverage-ratchet-summary.py"
+
+log() { printf '[coverage-ratchet] %s\n' "$*" >&2; }
+
+uncovered_total() { python3 "$PY" total "$1"; }
+summarize_json()  { python3 "$PY" summary "$1" "$ROOT" "$COVERAGE_TOP_N"; }
+
+run_tarpaulin() {
+  local out_dir="$1"
+  mkdir -p "$out_dir"
+  log "running cargo tarpaulin -> $out_dir (up to 75s)"
+  ( cd "$ROOT" && cargo tarpaulin --skip-clean --ignore-tests \
+      --out Json --output-dir "$out_dir" --timeout 120 >&2 ) || return $?
+  if [[ -f "$out_dir/tarpaulin-report.json" ]]; then
+    printf '%s\n' "$out_dir/tarpaulin-report.json"
+  else
+    log "tarpaulin report not found in $out_dir"
+    return 2
+  fi
+}
+
+ratchet() {
+  local base_ref="$1"
+  mkdir -p "$COVERAGE_DIR/head" "$COVERAGE_DIR/base"
+  local head_json base_json merge_base head_sha head_total base_total
+  head_json=$(run_tarpaulin "$COVERAGE_DIR/head")
+  merge_base=$(git merge-base HEAD "$base_ref" 2>/dev/null || git rev-parse "$base_ref")
+  head_sha=$(git rev-parse HEAD)
+  log "merge-base vs $base_ref = $merge_base"
+  log "stashing and checking out $merge_base"
+  git stash push -u -m "coverage-ratchet-wip" >/dev/null 2>&1 || true
+  git checkout -q "$merge_base"
+  if ! base_json=$(run_tarpaulin "$COVERAGE_DIR/base"); then
+    git checkout -q "$head_sha"; git stash pop >/dev/null 2>&1 || true; return 2
+  fi
+  git checkout -q "$head_sha"
+  git stash pop >/dev/null 2>&1 || true
+  head_total=$(uncovered_total "$head_json")
+  base_total=$(uncovered_total "$base_json")
+  {
+    echo "## Coverage Ratchet (untested lines)"
+    echo ""
+    echo "| metric | value |"
+    echo "| --- | --- |"
+    echo "| base ($merge_base) uncovered lines | $base_total |"
+    echo "| HEAD uncovered lines | $head_total |"
+    echo "| delta | $((head_total - base_total)) |"
+    echo ""
+    echo "### Top files by uncovered lines at HEAD"
+    echo '```'
+    summarize_json "$head_json"
+    echo '```'
+    echo ""
+    echo "Heuristic: unit=pure funcs; integration=I/O, routing, or protocol; property=data transforms."
+  } | tee "$COVERAGE_DIR/summary.md" >&2
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat "$COVERAGE_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  if (( head_total > base_total )); then
+    log "FAIL: HEAD has $head_total uncovered lines vs base $base_total (delta=+$((head_total - base_total)))"
+    return 1
+  fi
+  log "PASS: uncovered lines did not increase ($head_total <= $base_total)"
+}
+
+self_test() {
+  local tmp; tmp=$(mktemp -d); trap "rm -rf '$tmp'" EXIT
+  cat >"$tmp/base.json" <<'JSON'
+{"files":[{"path":["/","src","lib.rs"],"traces":[{"line":1,"stats":{"Line":1}},{"line":2,"stats":{"Line":0}},{"line":3,"stats":{"Line":0}},{"line":4,"stats":{"Line":0}}]}]}
+JSON
+  cat >"$tmp/head_ok.json" <<'JSON'
+{"files":[{"path":["/","src","lib.rs"],"traces":[{"line":1,"stats":{"Line":1}},{"line":2,"stats":{"Line":1}},{"line":3,"stats":{"Line":0}},{"line":4,"stats":{"Line":0}}]}]}
+JSON
+  cat >"$tmp/head_fail.json" <<'JSON'
+{"files":[{"path":["/","src","lib.rs"],"traces":[{"line":1,"stats":{"Line":0}},{"line":2,"stats":{"Line":0}},{"line":3,"stats":{"Line":0}},{"line":4,"stats":{"Line":0}},{"line":5,"stats":{"Line":0}}]},{"path":["/","src","data","client.rs"],"traces":[{"line":10,"stats":{"Line":0}},{"line":11,"stats":{"Line":0}}]}]}
+JSON
+  local base_n ok_n fail_n
+  base_n=$(uncovered_total "$tmp/base.json")
+  ok_n=$(uncovered_total "$tmp/head_ok.json")
+  fail_n=$(uncovered_total "$tmp/head_fail.json")
+  [[ "$base_n" == "3" && "$ok_n" == "2" && "$fail_n" == "7" ]] \
+    || { echo "self-test FAIL: totals base=$base_n ok=$ok_n fail=$fail_n" >&2; return 1; }
+  (( ok_n <= base_n )) && (( fail_n > base_n )) \
+    || { echo "self-test FAIL: decision gates" >&2; return 1; }
+  python3 "$PY" summary "$tmp/head_fail.json" / 10 | grep -q "integration (I/O path)" \
+    || { echo "self-test FAIL: I/O heuristic missing for data/client.rs" >&2; return 1; }
+  echo "self-test OK (base=$base_n ok=$ok_n fail=$fail_n, heuristics verified)"
+}
+
+main() {
+  case "${1:-}" in
+    --self-test) self_test ;;
+    --summary)   summarize_json "${2:?need tarpaulin JSON path}" ;;
+    --base)      ratchet "${2:?need base ref}" ;;
+    -h|--help)   sed -n '1,30p' "$0" ;;
+    "")          ratchet "$COVERAGE_BASE_REF" ;;
+    *)           echo "unknown arg: $1" >&2; exit 64 ;;
+  esac
+}
+main "$@"


### PR DESCRIPTION
Closes #16

- **job-id**: `xM9Bl`
- **oldest-issue-id**: `velib-mcp#9`

## Dev plan

Add a tarpaulin-based coverage ratchet that blocks PRs raising the
total *uncovered line count* vs the merge-base with `main`. Tracking
lines (not percentage) avoids false alarms when tested code is deleted
(per issue #16).

Shipped pieces:

- `scripts/coverage-ratchet.sh` — slim bash driver (<150 LOC) that
  runs tarpaulin on HEAD and the merge-base, compares totals, fails
  on a positive delta, and writes a markdown summary (mirrored to
  `$GITHUB_STEP_SUMMARY` when present, so no token scopes are
  required).
- `scripts/coverage-ratchet-summary.py` — companion parser/summariser
  that ranks files by uncovered lines, prints line ranges, and
  suggests a test paradigm (`unit` / `integration (I/O path)` /
  `integration (routing/protocol)` / `property (data transforms)`)
  via a documented path heuristic.
- `.github/workflows/coverage-ratchet.yml` — PR-only slow job +
  push+PR self-test job. Main-branch pushes are never gated on the
  delta check.  **NOTE**: this file could not be pushed by the
  GitHub App because it lacks the `workflows` scope — see the
  follow-up comment below.
- `.github/actions/coverage-ratchet/action.yml` — reusable composite
  action wrapping the same script.
- `docs/development/coverage-ratchet.md` and README/CLAUDE.md updates
  explaining the heuristic, agent loop, debug tips, and how to wire
  the pre-push hook via symlink (invoked, not installed).

Tarpaulin install: plain `cargo install cargo-tarpaulin --locked`
(matches the repo’s existing pattern — `ci.yml` uses this form for
`cargo-sort`, `cargo-audit`, and `cargo-hack`).

## Test plan

- [x] `scripts/coverage-ratchet.sh --self-test` passes (3 fixtures,
      asserts pass/fail decisions and heuristic output; runs in <1s
      without invoking cargo).
- [x] Ran `cargo install cargo-tarpaulin --locked` and verified the
      script produces a valid top-N summary against this codebase
      (22.07 % / 618 uncovered lines at HEAD; top offenders are
      `src/mcp/server.rs`, `src/mcp/handlers.rs`,
      `src/data/client.rs`, `src/data/retry.rs`, `src/types.rs`).
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features
      -- -D warnings`, and `cargo test --all-features` all green
      locally.
- [ ] CI-side verification once the workflow is in place (see
      follow-up).

## Follow-ups

- The workflow YAML needs to be merged manually (see PR comment).
- Consider promoting the heuristic to a config file once it grows
  beyond ~10 patterns — today it fits in one small regex per branch.
- Tune `--timeout` / retry behaviour if tarpaulin becomes flaky on
  slow CI runners.