### PR TITLE
arch: parser tests + panic fix, validation helper, dedupe resource dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,227 +1,82 @@
 # Projet CLAUDE : Serveur MCP Velib
 
 ## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP.
+Développeur Rust travaillant sur un projet open-source de serveur MCP.
 
-- **Répertoire de travail** : `~/code/velib-mcp/velib-mcp` (main repo)
-- **Architecture worktree** : Branches adjacentes (`~/code/velib-mcp/branch1/`, etc.)
 - **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
-
-### Structure du Projet
-```
-~/code/velib-mcp/
-├── velib-mcp/              # Dépôt principal (ce répertoire)
-│   ├── CLAUDE.md           # Configuration Claude partagée
-│   ├── src/                # Code source
-│   ├── docs/               # Documentation
-│   └── ...                 # Fichiers du projet
-├── branch1/                # Worktree pour branche feature
-│   ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-│   └── ...                 # Fichiers spécifiques à la branche
-└── branch2/                # Autre worktree
-    ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-    └── ...                 # Fichiers spécifiques à la branche
-```
-
-**Important** : Ce fichier CLAUDE.md est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
+- **Public cible** : assistants IA nécessitant l'accès aux données Velib
+- **Collaboration** : travail parallèle possible via `git worktree`
 
 ## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
+Serveur cloud MCP rendant accessibles aux assistants IA les deux jeux de
+données Velib de la ville de Paris :
 
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
+- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/
 - **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
 
-- **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
+**But** : exposer l'intégralité des informations de ces datasets pour la
+planification de transport et l'analyse des flux.
 
 ## État Actuel du Projet
 
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
+### Phases terminées
+- **Phase 0** : configuration projet, CI/CD, structure documentation
+- **Phase 1** : analyse des données Velib (15+ champs documentés)
+- **Phase 2A** : environnement et fondation serveur
+- **Phase 2B** : protocole MCP et types de base
+- **Phase 3A** : intégration API live et client de données
+- **Phase 3B** : handlers MCP avec données temps réel
+- **Phase 4** : nettoyage structure repository
 
-### Architecture Technique
-- **Serveur MCP Rust** pour données Velib Paris
-- **Deux datasets principaux** :
-  - Disponibilité stations en temps réel
-  - Localisations et métadonnées des stations
-- **Déploiement Scaleway** via GitHub Actions
-- **Suite de tests complète** (18+ tests)
-- **Validations sécurité** incluant limites zone service 50km
+Voir `docs/context/etat_actuel.md` pour l'historique détaillé.
 
-### Fichiers Importants
-- `/src/main.rs` - Point d'entrée principal
-- `/src/mcp/` - Implémentation protocole MCP
-- `/src/data/` - Client données et cache
-- `/src/types.rs` - Structures de données principales
-- `/docs/api/data_analysis.md` - Analyse données complète
-- `/docs/context/etat_actuel.md` - Suivi statut projet
+### Architecture technique
+- Serveur MCP en Rust pour données Velib Paris
+- Deux datasets : disponibilité temps réel + métadonnées stations
+- Déploiement Scaleway Container Serverless via GitHub Actions
+- Suite de tests (18+ tests)
+- Validations sécurité dont limite zone de service 50 km
 
-### Commandes Développement
+### Fichiers importants
+- `src/main.rs` — point d'entrée
+- `src/mcp/` — implémentation MCP
+- `src/data/` — client données et cache
+- `src/types.rs` — structures principales
+- `docs/api/data_analysis.md` — analyse des données
+- `docs/api/mcp_interface_spec.md` — spécification MCP
+- `docs/api/mcp_schemas.md` — schémas Rust
+
+## Commandes Développement
 ```bash
-cargo test                     # Tests complets
-cargo fmt                      # Formatage code
-cargo clippy                   # Analyse statique
-cargo audit                    # Audit sécurité
+cargo test       # Tests
+cargo fmt        # Formatage
+cargo clippy     # Lints
+cargo audit      # Audit sécurité
 ```
 
-### Déploiement
+Les hooks pre-commit (`cargo-husky`) sont détaillés dans `README.md` section
+« Pre-commit hooks ».
+
+## Déploiement
 - **Cible** : Scaleway Container Serverless
-- **Déclencheur** : Push vers branche main
+- **Déclencheur** : push sur `main`
 - **Registry** : Scaleway Container Registry
-- **Build** : Containerisation Podman
+- **Build** : image distroless construite avec Podman
 
-### Gestion Worktrees
+## Worktrees
 ```bash
-# Créer nouveau worktree
+# Créer un worktree
 git worktree add ../branch-name branch-name
-cd ../branch-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
 
-# Supprimer worktree
+# Supprimer un worktree
 git worktree remove ../branch-name
 git worktree prune
 ```
 
-## Processus de Développement Multi-Agents
+## Processus de Développement
 
-### Architecture Optimisée pour Performance, Qualité et Autonomie
+TDD : écrire les tests avant l'implémentation. À chaque commit, le hook
+pre-commit exécute `cargo clippy --fix`, `cargo fmt`, `cargo sort`, et
+`cargo deny check` — un échec annule le commit.
 
-Ce processus transforme l'approche linéaire traditionnelle en 5 phases parallèles pour maximiser l'efficacité d'équipe.
-
-#### Phase 1: Analyse Concurrente (PM + Test Designer)
-**Durée**: ~30 min | **Parallélisation**: PM et Test Designer travaillent simultanément
-
-**Product Manager (Rôle: Extraction de Valeur)**
-- Analyse issue GitHub avec template structuré
-- Extraction valeur métier claire et actionnable
-- Validation exigences avec dev-utilisateur
-- Production: Spécification fonctionnelle validée
-
-**Test Designer (Rôle: Planification Technique)**
-- Analyse technique parallèle de l'issue
-- Estimation nombre features/refactors uniques
-- Planification PRs et worktrees nécessaires
-- Production: Plan d'implémentation détaillé
-
-#### Phase 2: Fondation Tests (Test Designer)
-**Durée**: ~45 min | **Focus**: Environnement + Spécifications Test
-
-**Préparation Environnement**
-```bash
-# Création worktree optimisée avec template
-git worktree add ../feature-name feature/branch-name
-cd ../feature-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
-cargo test --no-run  # Pré-compilation dependencies
-```
-
-**Implémentation Tests TDD**
-- Tests d'intégration définissant comportement attendu
-- Tests unitaires pour composants critiques
-- Tests fuzz si applicable (données externes)
-- Validation: Tests échouent de manière attendue
-
-#### Phase 3: Sprint Implémentation (Ingénieur)
-**Durée**: Variable | **Focus**: Développement avec Validation Continue
-
-**Workflow Micro-Commits**
-```bash
-# Cycle développement optimisé
-while [[ $tests_failing ]]; do
-    # Implémentation incrémentale
-    cargo clippy --fix
-    cargo fmt
-    cargo test
-    git add -A && git commit -m "feat: micro-increment"
-done
-```
-
-**Intégration Continue Locale**
-- Validation automatique à chaque commit
-- Feedback temps réel des tests
-- Métriques qualité code continues
-- Résolution bloquants technique immédiate
-
-#### Phase 4: Révision Parallèle (Ingénieur + Réviseur)
-**Durée**: ~20 min | **Parallélisation**: Préparation + Analyse simultanées
-
-**Ingénieur (Préparation PR)**
-- Organisation commits en histoire cohérente
-- Rédaction description PR succincte
-- Validation finale checks locaux
-- Ouverture PR avec lien issue origine
-
-**Réviseur Senior (Analyse Qualité)**
-- Évaluation architecture et patterns Rust
-- Vérification couverture tests vs objectifs PM
-- Analyse lisibilité et extensibilité code
-- Validation sécurité et ergonomie
-
-**Boucle Feedback Structurée**
-- Critères évaluation standardisés
-- Dialogue constructif jusqu'accord
-- Résolution collaborative des points bloquants
-
-#### Phase 5: Intégration Automatisée (Ops)
-**Durée**: ~10 min | **Focus**: Déploiement et Validation
-
-**Merge et CI/CD**
-- Merge automatique post-approbation
-- Validation CI complète sur main
-- Monitoring santé déploiement
-- Métriques performance production
-
-### Templates et Checklists
-
-#### Template Analyse Issue (PM)
-```markdown
-## Valeur Métier
-- [ ] Problème utilisateur identifié
-- [ ] Solution proposée claire
-- [ ] Critères succès mesurables
-- [ ] Validation dev-utilisateur
-
-## Exigences Techniques
-- [ ] Contraintes techniques identifiées
-- [ ] Impact architecture évalué
-- [ ] Effort estimé (S/M/L/XL)
-```
-
-#### Checklist Qualité (Réviseur)
-```markdown
-## Architecture & Design
-- [ ] Patterns Rust idiomatiques respectés
-- [ ] Séparation responsabilités claire
-- [ ] Gestion erreurs appropriée
-- [ ] Performance optimisée
-
-## Tests & Couverture
-- [ ] Tests couvrent objectifs PM
-- [ ] Edge cases identifiés et testés
-- [ ] Intégration validée
-- [ ] Documentation à jour
-```
-
-### Métriques de Performance
-
-**Gains Attendus vs Processus Linéaire**
-- **Temps cycle**: -40% (parallélisation phases)
-- **Temps attente**: -60% (élimination handoffs)
-- **Qualité code**: +25% (validation continue)
-- **Autonomie équipe**: +50% (rôles auto-suffisants)
-
-### Intégration Architecture Existante
-
-Ce processus s'intègre parfaitement avec:
-- Architecture worktree existante (isolation parallèle)
-- CI/CD GitHub Actions (validation automatisée)
-- Hooks pre-commit (qualité continue)
-- Toolchain Rust standard (fmt, clippy, audit)
+Chaque PR référence son issue d'origine et passe la CI complète avant merge.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ A high-performance Model Context Protocol (MCP) server providing access to Paris
 
 ## Quick Start - Install with Claude Code
 
-Install and use the Velib MCP server with Claude Code in one command:
+Install the binary and register it with Claude Code:
 
 ```bash
-# Install and configure the server
+# Install the `velib-mcp` binary
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-claude config add-server velib-mcp "cargo run --release -- --port 3000"
+
+# Register the server with Claude Code
+claude mcp add velib-mcp velib-mcp -- --port 3000
 ```
 
 Then use in Claude Code:

--- a/docs/context/etat_actuel.md
+++ b/docs/context/etat_actuel.md
@@ -1,41 +1,49 @@
 # État Actuel du Projet Velib MCP
 
-## Phase Actuelle: Phase 2 - Architecture Système
+Date de dernière mise à jour: 2026-04-21
 
-### Statut: Prêt à commencer
-Date de dernière mise à jour: 2025-06-14
+## Phase Actuelle
 
-## Phase 0 - Configuration (TERMINÉE ✅)
-- ✅ Initialisation du projet Rust avec cargo
-- ✅ Configuration git et remote GitHub (DominicBurkart/velib-mcp)
-- ✅ Structure de documentation créée (/docs)
-- ✅ Configuration des hooks pre-commit (fmt, clippy, audit)
-- ✅ Workflow CI/CD GitHub Actions configuré
-- ✅ Dockerfile créé pour déploiement Scaleway (compatible Podman)
-- ✅ Système de suivi de contexte Claude initialisé
-- ✅ Documentation projet et README créés
+Phases 0–4 terminées (voir `CLAUDE.md` section « État Actuel du Projet » pour
+le détail faisant autorité). Le serveur expose les handlers MCP avec
+intégration des données live et est déployable sur Scaleway Container
+Serverless.
 
-## Phase 1 - Analyse des Données (TERMINÉE ✅)
-- ✅ Analyse complète du dataset disponibilité temps réel
-- ✅ Analyse complète du dataset emplacements des stations
-- ✅ Identification structure données et colonnes (15+ champs)
-- ✅ Documentation technique détaillée (/docs/api/data_analysis.md)
-- ✅ Schémas de données Rust complets (/docs/api/mcp_schemas.md)
-- ✅ Spécification interfaces MCP avec 5 tools (/docs/api/mcp_interface_spec.md)
+## Historique des Phases
 
-## Prochaines Étapes (Phase 2)
-1. 🎯 Architecturer le système et composants
-2. 🎯 Définir l'organisation modulaire du code Rust
-3. 🎯 Planifier l'approche agile avec PRs cohérentes
-4. 🎯 Documenter l'architecture dans /docs/decisions
+### Phase 0 — Configuration (terminée)
+- Initialisation du projet Rust avec cargo
+- Configuration git et remote GitHub (dominicburkart/velib-mcp)
+- Structure de documentation créée (`docs/`)
+- Hooks pre-commit (fmt, clippy, audit) — voir `README.md` section
+  « Pre-commit hooks »
+- Workflow CI/CD GitHub Actions
+- Dockerfile pour déploiement Scaleway (compatible Podman)
+- README et documentation initiale
+
+### Phase 1 — Analyse des Données (terminée)
+- Analyse des deux datasets (temps réel + emplacements)
+- Documentation technique : `docs/api/data_analysis.md`
+- Schémas Rust : `docs/api/mcp_schemas.md`
+- Spécification MCP (5 tools) : `docs/api/mcp_interface_spec.md`
+
+### Phase 2 — Fondation Serveur (terminée)
+- Environnement Rust et structure modulaire
+- Protocole MCP et types de base (`src/mcp/`, `src/types.rs`)
+
+### Phase 3 — Intégration Données (terminée)
+- Client API live et cache (`src/data/`)
+- Handlers MCP avec données temps réel
+
+### Phase 4 — Nettoyage Repository (terminée)
+- Suppression des worktrees committés par erreur
 
 ## Dépendances Techniques
-- Rust (version stable récente)
-- GitHub Actions pour CI/CD
-- Scaleway CLI pour déploiement
+- Rust stable (voir `rust-toolchain.toml`)
+- GitHub Actions (CI/CD)
+- Scaleway CLI (`scw`) pour déploiement
 - Podman pour conteneurisation
 
-## Notes Importantes
-- Repository configuré pour github.com/dominicburkart/velib-mcp
-- Email configuré: dominic@dominic.computer
-- Approche TDD requise pour toutes les fonctionnalités
+## Notes
+- Email de commit : dominic@dominic.computer
+- Approche TDD pour toutes les fonctionnalités

--- a/docs/development/project_prompt.md
+++ b/docs/development/project_prompt.md
@@ -1,19 +1,11 @@
-# Projet Claude Code : Serveur MCP Velib
+# Prompt projet — Serveur MCP Velib
 
-## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP. 
-- **Répertoire de travail** : `~/code/velib-mcp`
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
+Le prompt de travail pour ce projet est maintenu dans `CLAUDE.md` à la racine
+du dépôt. Voir notamment :
 
-## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
+- `CLAUDE.md` — « Contexte et Rôle »
+- `CLAUDE.md` — « Objectif du Projet »
+- `CLAUDE.md` — « État Actuel du Projet »
 
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
-
-**But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
-
-[... rest of the original prompt content ...]
+Ce fichier est conservé comme point d'entrée historique ; toute modification
+du prompt doit être faite dans `CLAUDE.md` pour éviter la divergence.

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -103,7 +103,7 @@ impl VelibDataClient {
             }
 
             for record in records {
-                if let Ok(station) = self.parse_reference_station(record) {
+                if let Ok(station) = Self::parse_reference_station(record) {
                     all_stations.push(station);
                 }
             }
@@ -161,7 +161,7 @@ impl VelibDataClient {
             }
 
             for record in records {
-                if let Ok((station_code, status)) = self.parse_realtime_status(record) {
+                if let Ok((station_code, status)) = Self::parse_realtime_status(record) {
                     all_status.insert(station_code, status);
                 }
             }
@@ -222,7 +222,7 @@ impl VelibDataClient {
     }
 
     /// Parse reference station data from API response
-    fn parse_reference_station(&self, record: &Value) -> Result<StationReference> {
+    fn parse_reference_station(record: &Value) -> Result<StationReference> {
         let station_code = record["stationcode"]
             .as_str()
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
@@ -238,17 +238,23 @@ impl VelibDataClient {
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing capacity")))?
             as u16;
 
-        // Parse coordinates from coordonnees_geo
+        // Parse coordinates from coordonnees_geo.
+        // Use `.get(...)` rather than `geo_point["lat"]`: indexing into a
+        // `serde_json::Map` panics on missing keys, so we need an explicit
+        // lookup to surface a clean `Err` when the upstream payload is
+        // missing `lat`/`lon`.
         let geo_point = record["coordonnees_geo"]
             .as_object()
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing geo coordinates")))?;
 
-        let latitude = geo_point["lat"]
-            .as_f64()
+        let latitude = geo_point
+            .get("lat")
+            .and_then(Value::as_f64)
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing latitude")))?;
 
-        let longitude = geo_point["lon"]
-            .as_f64()
+        let longitude = geo_point
+            .get("lon")
+            .and_then(Value::as_f64)
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing longitude")))?;
 
         let coordinates = crate::types::Coordinates::new(latitude, longitude);
@@ -270,7 +276,7 @@ impl VelibDataClient {
     }
 
     /// Parse real-time status data from API response
-    fn parse_realtime_status(&self, record: &Value) -> Result<(String, RealTimeStatus)> {
+    fn parse_realtime_status(record: &Value) -> Result<(String, RealTimeStatus)> {
         let station_code = record["stationcode"]
             .as_str()
             .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
@@ -324,5 +330,311 @@ impl VelibDataClient {
         let reference_size = self.reference_cache.size().await;
         let realtime_size = self.realtime_cache.size().await;
         (reference_size, realtime_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for API response parsers.
+    //!
+    //! The `fetch_*` methods on `VelibDataClient` are only exercised against
+    //! the live Paris Open Data API. The parsers that translate each record
+    //! into a domain type, however, are pure functions over `serde_json::Value`
+    //! and are the highest-risk component in this module: a schema drift in
+    //! the upstream API would surface here first. These tests pin down the
+    //! parser contract so regressions surface as unit-test failures rather
+    //! than silently-dropped records in production.
+    //!
+    //! Invariants exercised:
+    //! - Reference records missing any required field produce `Err`.
+    //! - Realtime records missing the `stationcode` produce `Err`; other
+    //!   fields have documented defaults.
+    //! - Status derivation: `is_installed`/`is_renting`/`is_returning` map
+    //!   deterministically to `StationStatus::{Open, Maintenance, Closed}`.
+    //! - `duedate` falls back to "now" when absent or unparseable (parser
+    //!   must not panic on garbage timestamps).
+    use super::*;
+    use serde_json::json;
+
+    fn valid_reference_record() -> Value {
+        json!({
+            "stationcode": "16107",
+            "name": "Benjamin Godard - Victor Hugo",
+            "capacity": 35,
+            "coordonnees_geo": {
+                "lat": 48.8651,
+                "lon": 2.2755
+            }
+        })
+    }
+
+    fn valid_realtime_record() -> Value {
+        json!({
+            "stationcode": "16107",
+            "mechanical": 5,
+            "ebike": 3,
+            "numdocksavailable": 27,
+            "is_installed": "OUI",
+            "is_renting": "OUI",
+            "is_returning": "OUI",
+            "duedate": "2024-01-15T12:30:00+00:00"
+        })
+    }
+
+    // --- parse_reference_station: happy path ---
+
+    #[test]
+    fn parses_valid_reference_record() {
+        let record = valid_reference_record();
+        let station = VelibDataClient::parse_reference_station(&record).unwrap();
+        assert_eq!(station.station_code, "16107");
+        assert_eq!(station.name, "Benjamin Godard - Victor Hugo");
+        assert_eq!(station.capacity, 35);
+        assert!((station.coordinates.latitude - 48.8651).abs() < 1e-9);
+        assert!((station.coordinates.longitude - 2.2755).abs() < 1e-9);
+        // Capabilities are not present in the API and default to false.
+        assert!(!station.capabilities.accepts_credit_card);
+        assert!(!station.capabilities.has_charging_station);
+        assert!(!station.capabilities.is_virtual_station);
+    }
+
+    // --- parse_reference_station: missing required fields each produce Err ---
+
+    #[test]
+    fn reference_missing_station_code_errors() {
+        let mut record = valid_reference_record();
+        record.as_object_mut().unwrap().remove("stationcode");
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    #[test]
+    fn reference_missing_name_errors() {
+        let mut record = valid_reference_record();
+        record.as_object_mut().unwrap().remove("name");
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    #[test]
+    fn reference_missing_capacity_errors() {
+        let mut record = valid_reference_record();
+        record.as_object_mut().unwrap().remove("capacity");
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    #[test]
+    fn reference_missing_coordinates_errors() {
+        let mut record = valid_reference_record();
+        record.as_object_mut().unwrap().remove("coordonnees_geo");
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    #[test]
+    fn reference_missing_latitude_errors() {
+        // Regression: previously panicked because `geo_point["lat"]` indexes
+        // a serde_json `Map` (panics on missing key). Now returns Err.
+        let mut record = valid_reference_record();
+        record["coordonnees_geo"]
+            .as_object_mut()
+            .unwrap()
+            .remove("lat");
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    #[test]
+    fn reference_missing_longitude_errors() {
+        // Regression: see `reference_missing_latitude_errors`.
+        let mut record = valid_reference_record();
+        record["coordonnees_geo"]
+            .as_object_mut()
+            .unwrap()
+            .remove("lon");
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    // --- parse_reference_station: wrong field types produce Err ---
+
+    #[test]
+    fn reference_wrong_field_types_error() {
+        // stationcode as number (not string)
+        let record = json!({
+            "stationcode": 16107,
+            "name": "x",
+            "capacity": 35,
+            "coordonnees_geo": { "lat": 48.86, "lon": 2.27 }
+        });
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+
+        // capacity as string
+        let record = json!({
+            "stationcode": "16107",
+            "name": "x",
+            "capacity": "35",
+            "coordonnees_geo": { "lat": 48.86, "lon": 2.27 }
+        });
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+
+        // coordonnees_geo as string instead of object
+        let record = json!({
+            "stationcode": "16107",
+            "name": "x",
+            "capacity": 35,
+            "coordonnees_geo": "48.86,2.27"
+        });
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    #[test]
+    fn reference_empty_object_errors() {
+        let record = json!({});
+        assert!(VelibDataClient::parse_reference_station(&record).is_err());
+    }
+
+    // --- parse_realtime_status: happy path ---
+
+    #[test]
+    fn parses_valid_realtime_record_as_open() {
+        let record = valid_realtime_record();
+        let (code, status) = VelibDataClient::parse_realtime_status(&record).unwrap();
+        assert_eq!(code, "16107");
+        assert_eq!(status.bikes.mechanical, 5);
+        assert_eq!(status.bikes.electric, 3);
+        assert_eq!(status.available_docks, 27);
+        assert_eq!(status.status, StationStatus::Open);
+    }
+
+    // --- parse_realtime_status: station_code is the only required field ---
+
+    #[test]
+    fn realtime_missing_station_code_errors() {
+        let mut record = valid_realtime_record();
+        record.as_object_mut().unwrap().remove("stationcode");
+        assert!(VelibDataClient::parse_realtime_status(&record).is_err());
+    }
+
+    #[test]
+    fn realtime_station_code_wrong_type_errors() {
+        let record = json!({ "stationcode": 16107 });
+        assert!(VelibDataClient::parse_realtime_status(&record).is_err());
+    }
+
+    #[test]
+    fn realtime_minimal_record_defaults_fields() {
+        // Only stationcode present: everything else must default without error.
+        let record = json!({ "stationcode": "42" });
+        let (code, status) = VelibDataClient::parse_realtime_status(&record).unwrap();
+        assert_eq!(code, "42");
+        assert_eq!(status.bikes.mechanical, 0);
+        assert_eq!(status.bikes.electric, 0);
+        assert_eq!(status.available_docks, 0);
+        // is_installed defaults to "NON" -> Closed
+        assert_eq!(status.status, StationStatus::Closed);
+    }
+
+    // --- parse_realtime_status: status derivation matrix ---
+
+    fn realtime_with_flags(
+        is_installed: &str,
+        is_renting: &str,
+        is_returning: &str,
+    ) -> StationStatus {
+        let record = json!({
+            "stationcode": "1",
+            "is_installed": is_installed,
+            "is_renting": is_renting,
+            "is_returning": is_returning,
+        });
+        VelibDataClient::parse_realtime_status(&record)
+            .unwrap()
+            .1
+            .status
+    }
+
+    #[test]
+    fn status_open_requires_installed_renting_and_returning() {
+        assert_eq!(
+            realtime_with_flags("OUI", "OUI", "OUI"),
+            StationStatus::Open
+        );
+    }
+
+    #[test]
+    fn status_maintenance_when_installed_but_not_both_renting_and_returning() {
+        // Installed but not renting
+        assert_eq!(
+            realtime_with_flags("OUI", "NON", "OUI"),
+            StationStatus::Maintenance
+        );
+        // Installed but not returning
+        assert_eq!(
+            realtime_with_flags("OUI", "OUI", "NON"),
+            StationStatus::Maintenance
+        );
+        // Installed but neither
+        assert_eq!(
+            realtime_with_flags("OUI", "NON", "NON"),
+            StationStatus::Maintenance
+        );
+    }
+
+    #[test]
+    fn status_closed_when_not_installed() {
+        assert_eq!(
+            realtime_with_flags("NON", "OUI", "OUI"),
+            StationStatus::Closed
+        );
+        // Any non-"OUI" is_installed value is treated as closed.
+        assert_eq!(
+            realtime_with_flags("unknown", "OUI", "OUI"),
+            StationStatus::Closed
+        );
+    }
+
+    // --- parse_realtime_status: last_update timestamp handling ---
+
+    #[test]
+    fn realtime_parses_valid_rfc3339_duedate() {
+        let record = json!({
+            "stationcode": "1",
+            "duedate": "2024-01-15T12:30:00+00:00",
+        });
+        let (_, status) = VelibDataClient::parse_realtime_status(&record).unwrap();
+        assert_eq!(status.last_update.to_rfc3339(), "2024-01-15T12:30:00+00:00");
+    }
+
+    #[test]
+    fn realtime_falls_back_to_now_for_unparseable_duedate() {
+        // Non-RFC3339 string must fall back to `Utc::now()` rather than error.
+        let before = Utc::now();
+        let record = json!({
+            "stationcode": "1",
+            "duedate": "not-a-timestamp",
+        });
+        let (_, status) = VelibDataClient::parse_realtime_status(&record).unwrap();
+        let after = Utc::now();
+        assert!(status.last_update >= before && status.last_update <= after);
+    }
+
+    #[test]
+    fn realtime_falls_back_to_now_for_missing_duedate() {
+        let before = Utc::now();
+        let record = json!({ "stationcode": "1" });
+        let (_, status) = VelibDataClient::parse_realtime_status(&record).unwrap();
+        let after = Utc::now();
+        assert!(status.last_update >= before && status.last_update <= after);
+    }
+
+    // --- parse_realtime_status: numeric fields cast silently ---
+
+    #[test]
+    fn realtime_numeric_fields_truncate_to_u16() {
+        // Values larger than u16::MAX are cast via `as u16` (wrap). The
+        // upstream API never produces such values, but pinning the behavior
+        // makes any future switch to checked conversion a deliberate decision.
+        let record = json!({
+            "stationcode": "1",
+            "mechanical": 70_000u64,
+        });
+        let parsed = VelibDataClient::parse_realtime_status(&record);
+        assert!(parsed.is_ok());
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -23,6 +23,23 @@ const PARIS_CITY_HALL: Coordinates = Coordinates {
     longitude: 2.3514,
 };
 
+/// Validate that a coordinate is a well-formed Paris-metro point within the
+/// 50 km service area. Returns `InvalidCoordinates` for malformed points and
+/// `OutsideServiceArea` for points outside the service radius.
+fn validate_service_area(point: &Coordinates) -> Result<()> {
+    if !point.is_valid_paris_metro() {
+        return Err(Error::InvalidCoordinates {
+            latitude: point.latitude,
+            longitude: point.longitude,
+        });
+    }
+    if !point.is_within_paris_service_area() {
+        let distance_km = point.distance_to(&PARIS_CITY_HALL) / 1000.0;
+        return Err(Error::OutsideServiceArea { distance_km });
+    }
+    Ok(())
+}
+
 /// Find stations near a point, filtering by distance and a custom predicate,
 /// sorted by distance and truncated to `limit` results.
 ///
@@ -106,18 +123,7 @@ impl McpToolHandler {
         }
 
         let query_point = Coordinates::new(input.latitude, input.longitude);
-        if !query_point.is_valid_paris_metro() {
-            return Err(Error::InvalidCoordinates {
-                latitude: input.latitude,
-                longitude: input.longitude,
-            });
-        }
-
-        // Enforce 50km distance limit from Paris City Hall
-        if !query_point.is_within_paris_service_area() {
-            let distance_km = query_point.distance_to(&PARIS_CITY_HALL) / 1000.0;
-            return Err(Error::OutsideServiceArea { distance_km });
-        }
+        validate_service_area(&query_point)?;
 
         // Fetch live station data
         let mut data_client = self.data_client.write().await;
@@ -176,7 +182,9 @@ impl McpToolHandler {
         let start_time = Instant::now();
 
         if input.query.len() < 2 {
-            return Err(Error::Internal(anyhow::anyhow!("Search query too short")));
+            return Err(Error::Validation(
+                "Search query must be at least 2 characters".to_string(),
+            ));
         }
 
         if input.limit > MAX_RESULT_LIMIT {
@@ -294,30 +302,8 @@ impl McpToolHandler {
         &self,
         input: PlanBikeJourneyInput,
     ) -> Result<PlanBikeJourneyOutput> {
-        if !input.origin.is_valid_paris_metro() {
-            return Err(Error::InvalidCoordinates {
-                latitude: input.origin.latitude,
-                longitude: input.origin.longitude,
-            });
-        }
-
-        if !input.destination.is_valid_paris_metro() {
-            return Err(Error::InvalidCoordinates {
-                latitude: input.destination.latitude,
-                longitude: input.destination.longitude,
-            });
-        }
-
-        // Enforce 50km distance limit from Paris City Hall for both origin and destination
-        if !input.origin.is_within_paris_service_area() {
-            let distance_km = input.origin.distance_to(&PARIS_CITY_HALL) / 1000.0;
-            return Err(Error::OutsideServiceArea { distance_km });
-        }
-
-        if !input.destination.is_within_paris_service_area() {
-            let distance_km = input.destination.distance_to(&PARIS_CITY_HALL) / 1000.0;
-            return Err(Error::OutsideServiceArea { distance_km });
-        }
+        validate_service_area(&input.origin)?;
+        validate_service_area(&input.destination)?;
 
         // Find nearby stations for pickup and dropoff using live data
         let mut data_client = self.data_client.write().await;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -445,74 +445,48 @@ async fn handle_resource(
     handler: Arc<McpToolHandler>,
     start_time: Instant,
 ) -> Response {
-    match uri.as_str() {
-        "velib://stations/reference" => {
-            match get_reference_stations_resource(Arc::clone(&handler)).await {
-                Ok(response) => Json(response).into_response(),
-                Err(e) => {
-                    error!("Failed to get reference stations: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({
-                            "error": "Failed to fetch reference stations",
-                            "details": e.to_string()
-                        })),
-                    )
-                        .into_response()
-                }
-            }
+    // Branch-specific logic is limited to picking which resource future to
+    // await and a human-readable subject used in the error payload. The
+    // success/error serialization is shared below.
+    let (result, subject): (Result<Value>, &str) = match uri.as_str() {
+        "velib://stations/reference" => (
+            get_reference_stations_resource(Arc::clone(&handler)).await,
+            "reference stations",
+        ),
+        "velib://stations/realtime" => (
+            get_realtime_stations_resource(Arc::clone(&handler)).await,
+            "real-time stations",
+        ),
+        "velib://stations/complete" => (
+            get_complete_stations_resource(Arc::clone(&handler)).await,
+            "complete stations",
+        ),
+        "velib://health" => (
+            get_health_resource(Arc::clone(&handler), start_time).await,
+            "health status",
+        ),
+        _ => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "Resource not found"})),
+            )
+                .into_response();
         }
-        "velib://stations/realtime" => {
-            match get_realtime_stations_resource(Arc::clone(&handler)).await {
-                Ok(response) => Json(response).into_response(),
-                Err(e) => {
-                    error!("Failed to get real-time stations: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({
-                            "error": "Failed to fetch real-time stations",
-                            "details": e.to_string()
-                        })),
-                    )
-                        .into_response()
-                }
-            }
+    };
+
+    match result {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => {
+            error!("Failed to get {}: {}", subject, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": format!("Failed to fetch {subject}"),
+                    "details": e.to_string()
+                })),
+            )
+                .into_response()
         }
-        "velib://stations/complete" => {
-            match get_complete_stations_resource(Arc::clone(&handler)).await {
-                Ok(response) => Json(response).into_response(),
-                Err(e) => {
-                    error!("Failed to get complete stations: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({
-                            "error": "Failed to fetch complete stations",
-                            "details": e.to_string()
-                        })),
-                    )
-                        .into_response()
-                }
-            }
-        }
-        "velib://health" => match get_health_resource(Arc::clone(&handler), start_time).await {
-            Ok(response) => Json(response).into_response(),
-            Err(e) => {
-                error!("Failed to get health status: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({
-                        "error": "Failed to fetch health status",
-                        "details": e.to_string()
-                    })),
-                )
-                    .into_response()
-            }
-        },
-        _ => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "Resource not found"})),
-        )
-            .into_response(),
     }
 }
 


### PR DESCRIPTION
## Summary

Architecture-alignment pass on the data + MCP layers. Three independent cleanups on this branch, all keeping behavior (one error variant corrected). 135 tests pass; `cargo clippy -D warnings` and `cargo fmt --check` clean.

### `src/data/client.rs` — parser unit tests + missing-lat/lon panic fix (commit `7fd4e50`)

`parse_reference_station` and `parse_realtime_status` had zero direct coverage — they were reachable only through the live-API-only `fetch_*` methods. That means upstream schema drift would silently drop records via `if let Ok(station) = ...` with no CI signal.

- Promote both parsers from `fn(&self, ...)` to `fn(...)` (they never used `self`) so the adjacent `#[cfg(test)]` module can call them without a client instance.
- +20 unit tests pinning every required-field branch, status-derivation matrix, and `duedate` fallback.
- Fix latent panic: `geo_point["lat"]` indexes into a `serde_json::Map`, which panics on missing keys rather than returning the documented `Err`. Swap to `.get("lat").and_then(Value::as_f64)`. Two of the new tests regression-pin this.

Net: lib tests 64 → 84, no public-API change, no new deps.

### `src/mcp/handlers.rs` — consolidate service-area validation + correct error variant (commit `f53deb4`)

- Extract `validate_service_area(&Coordinates) -> Result<()>`. The Paris-metro check + 50 km service-area check was inlined once in `find_nearby_stations` and twice in `plan_bike_journey` (origin and destination), all emitting the same `InvalidCoordinates` / `OutsideServiceArea` errors. Collapses to one helper + three call sites.
- `search_stations_by_name` returned `Error::Internal(anyhow!("Search query too short"))` for a 1-character query, which maps to MCP `-32603 internal_error`. A short query is invalid client input, not an internal failure — switch to `Error::Validation(..)` so it surfaces as `-32602 invalid_params` / `validation_error`, matching the sibling input-validation branches and the `CLAUDE.md` "Gestion erreurs appropriée" precept.

### `src/mcp/server.rs` — dedupe `handle_resource` match arms (commit `f53deb4`)

Four copies of the same `match { Ok => Json, Err => error!+500 }` scaffold, one per resource URI. Factored into a single match that picks the future + subject string, then shares one success/error tail. Identical behavior.

### `docs` / `README` / `CLAUDE.md` — stale-content trim (commit `121c4a0`)

- README: fix Claude Code install command (`claude mcp add` instead of `claude config add-server`), stop conflating `cargo install` with `cargo run --release`.
- CLAUDE.md: drop the fabricated multi-agents-process section with invented "+25% quality, -40% cycle time" metrics; keep context, objectives, current state, file map, dev commands, deployment.
- `docs/context/etat_actuel.md`: refresh from "Phase 2 not started, 2025-06-14" to phases 0–4 done, matching CLAUDE.md.
- `docs/development/project_prompt.md`: remove `[... rest of the original prompt content ...]` placeholder + duplicate intro; point at CLAUDE.md as the single source of truth.

Aggregate: `+3xx / -1xx` LOC dominated by the new parser tests; arch cleanup on its own is -40 LOC.

## Test plan

- [x] `cargo test --lib` — 84 passing (from 64).
- [x] `cargo test --all` — 135 passing, no regressions.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Pre-push hook (`cargo test --all`) passed.
- [ ] CI green on this branch.

https://claude.ai/code/session_017vrZ4D421Ty4uKSgmm7Qsb