### PR TITLE
fix(deny): allow Unicode-3.0, bump rand, ignore rustls-pemfile advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,9 +1027,9 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,8 @@
+[advisories]
+ignore = [
+  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; transitive via reqwest 0.11. No safe upgrade without bumping reqwest to 0.12 (tracked separately)." },
+]
+
 [licenses]
 allow = [
   "MIT",
@@ -7,6 +12,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "Unicode-DFS-2016",
+  "Unicode-3.0",
   "CC0-1.0",
   "Zlib",
   "OpenSSL",


### PR DESCRIPTION
## Summary

`cargo deny check` is currently failing against `main` for three reasons; CI does not run deny, so this went unnoticed. Fixes below.

- **Licenses**: newer `icu_*` crates (pulled via `reqwest` → `url` → `idna`) ship under `Unicode-3.0`. Added to the license allow list alongside `Unicode-DFS-2016`.
- **RUSTSEC-2026-0097** (`rand` 0.8.5 unsoundness): fixed by bumping `rand` to `0.8.6` via `cargo update -p rand --precise 0.8.6`. Semver-compatible, no manifest change.
- **RUSTSEC-2025-0134** (`rustls-pemfile` unmaintained): transitive via `reqwest` 0.11. The only real fix is bumping to `reqwest` 0.12, which is a larger lift. Ignored with a documented reason for now.

Unblocks the pre-commit hook, which currently fails on every commit that goes through it.

## Test plan

- [x] `cargo deny check` passes locally (`advisories ok, bans ok, licenses ok, sources ok`)
- [ ] CI green on this PR