### PR TITLE
chore(deny): allow Unicode-3.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "Unicode-DFS-2016",
+  "Unicode-3.0",
   "CC0-1.0",
   "Zlib",
   "OpenSSL",


### PR DESCRIPTION
## Summary

Add \`Unicode-3.0\` to \`deny.toml\`'s license allowlist. ICU crates (\`icu_collections\`, \`icu_locale_core\`, \`icu_normalizer\`, etc.) migrated from \`Unicode-DFS-2016\` to \`Unicode-3.0\` upstream, so cargo-deny currently rejects any dep graph that pulls them in.

## Coupling note

Sibling PR #112 (\`chore(deps): bump reqwest+rand\`) is what introduces ICU 2.0 into the tree. This PR is the license side of the same chicken-and-egg — local \`.git/hooks/pre-commit\` runs licenses + advisories together, so neither PR can pass the hook on its own. Pre-commit bypassed once (with user authorization). CI runs cargo-deny cleanly once both are on main.

## Test plan

- [x] \`cargo deny check licenses\` — ok
- [ ] CI green on this PR
- [ ] CI green after #112 merges