### PR TITLE
feat(mcp): add describe_api tool + velib://api/description resource (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ This project exposes two key Parisian datasets through MCP:
 - `search_stations_by_name`: Search stations by name with optional fuzzy matching
 - `get_area_statistics`: Get aggregated statistics for a geographic area
 - `plan_bike_journey`: Plan a bike journey with pickup and dropoff suggestions
+- `describe_api`: Return the full machine-readable API contract (server info,
+  service area, units, cache TTLs, enum definitions, per-tool schemas, error
+  codes). Pass `format: "markdown"` for a human-readable rendering.
+
+### Self-documentation
+
+The same payload is also exposed as an MCP resource at
+`velib://api/description` (mime type `application/json`). Call `describe_api`
+or fetch the resource once at session start so the agent can reason about
+every tool, enum, and error code without reading the source.
 
 ## Integration with Other AI Tools
 

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -15,8 +15,10 @@ const VELIB_STATIONS_URL: &str = "https://opendata.paris.fr/api/explore/v2.1/cat
 const VELIB_REALTIME_URL: &str = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/records";
 
 // Cache TTLs
-const REFERENCE_CACHE_TTL_MINUTES: i64 = 5; // 5 minutes for reference data
-const REALTIME_CACHE_TTL_MINUTES: i64 = 2; // 2 minutes for real-time data
+// These are exposed as `pub` so `mcp::describe` can report them in the
+// self-documentation endpoint without duplicating the values.
+pub const REFERENCE_CACHE_TTL_MINUTES: i64 = 5; // 5 minutes for reference data
+pub const REALTIME_CACHE_TTL_MINUTES: i64 = 2; // 2 minutes for real-time data
 
 #[derive(Debug)]
 pub struct VelibDataClient {

--- a/src/mcp/describe.rs
+++ b/src/mcp/describe.rs
@@ -1,0 +1,500 @@
+//! Self-documentation for the Velib MCP API.
+//!
+//! This module is the **single source of truth** for the machine-readable
+//! description of the server's public contract that LLM clients discover at
+//! runtime: server info, service area, units, cache TTLs, enum definitions,
+//! per-tool input/output schemas, and error codes.
+//!
+//! The payload is assembled from:
+//! - Cache TTL constants imported from [`crate::data::client`] so the document
+//!   cannot drift from the actual cache configuration.
+//! - Per-tool `inputSchema` values taken from
+//!   [`crate::mcp::server::tool_definitions`] so the schemas reported here are
+//!   byte-for-byte the same ones returned by the `tools/list` JSON-RPC method.
+//! - Static metadata (enum variants, units, service-area bounds, error codes)
+//!   hard-coded here; any change to the corresponding Rust types must be
+//!   reflected here and is exercised by the drift-guard tests in
+//!   `tests/mcp_describe_tests.rs`.
+//!
+//! Both the `describe_api` tool (`tools/call`) and the
+//! `velib://api/description` resource (`resources/read`) render from the exact
+//! same JSON produced by [`api_description`].
+
+use serde_json::{json, Value};
+
+use crate::data::client::{REALTIME_CACHE_TTL_MINUTES, REFERENCE_CACHE_TTL_MINUTES};
+use crate::mcp::server::tool_definitions;
+use crate::types::{PARIS_CITY_HALL, PARIS_SERVICE_AREA_MAX_METERS};
+
+const SERVER_NAME: &str = "velib-mcp";
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const MCP_PROTOCOL: &str = "2024-11-05";
+
+/// Build the full machine-readable API description.
+///
+/// Pure function: no I/O, no allocations that depend on runtime state beyond
+/// formatting the returned JSON value. Safe to call from any context.
+#[must_use]
+pub fn api_description() -> Value {
+    json!({
+        "server": {
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION,
+            "protocol": MCP_PROTOCOL,
+            "endpoints": {
+                "http_jsonrpc": "POST /mcp",
+                "websocket_jsonrpc": "GET /mcp/ws (upgrade)",
+                "resource_http": "GET /resources/<uri>"
+            }
+        },
+        "service_area": {
+            "reference_point": {
+                "lat": PARIS_CITY_HALL.latitude,
+                "lon": PARIS_CITY_HALL.longitude,
+                "label": "Paris City Hall (Hôtel de Ville)"
+            },
+            "max_radius_meters": PARIS_SERVICE_AREA_MAX_METERS,
+            "bounding_box": {
+                "lat_min": 48.7,
+                "lat_max": 49.0,
+                "lon_min": 2.0,
+                "lon_max": 2.6
+            }
+        },
+        "units": {
+            "distance": "meters",
+            "time": "seconds_unix_utc",
+            "walking_distance": "meters",
+            "coordinates": "wgs84_decimal_degrees",
+            "occupancy_rate": "ratio_0_to_1"
+        },
+        "caching": {
+            "reference_ttl_seconds": REFERENCE_CACHE_TTL_MINUTES * 60,
+            "realtime_ttl_seconds": REALTIME_CACHE_TTL_MINUTES * 60,
+            "freshness_thresholds_minutes": {
+                "fresh": "<10",
+                "recent": "10-30",
+                "stale": "30-120",
+                "very_stale": ">120"
+            }
+        },
+        "enums": enums(),
+        "tools": tools_with_schemas(),
+        "resources": resources(),
+        "error_codes": error_codes()
+    })
+}
+
+/// Render the API description as Markdown. Uses [`api_description`] as its
+/// only data source so the two formats can never drift.
+#[must_use]
+pub fn api_description_markdown() -> String {
+    let desc = api_description();
+    let mut out = String::new();
+
+    let name = desc["server"]["name"].as_str().unwrap_or(SERVER_NAME);
+    let version = desc["server"]["version"].as_str().unwrap_or(SERVER_VERSION);
+    out.push_str(&format!("# {name} API ({version})\n\n"));
+
+    out.push_str("## Server\n\n");
+    out.push_str(&format!("- **Name**: `{name}`\n"));
+    out.push_str(&format!("- **Version**: `{version}`\n"));
+    if let Some(protocol) = desc["server"]["protocol"].as_str() {
+        out.push_str(&format!("- **MCP protocol**: `{protocol}`\n"));
+    }
+    out.push('\n');
+
+    out.push_str("## Service area\n\n");
+    let rp = &desc["service_area"]["reference_point"];
+    if let (Some(lat), Some(lon), Some(label)) =
+        (rp["lat"].as_f64(), rp["lon"].as_f64(), rp["label"].as_str())
+    {
+        out.push_str(&format!("Reference point: {label} ({lat:.4}, {lon:.4}).\n"));
+    }
+    if let Some(max_m) = desc["service_area"]["max_radius_meters"].as_f64() {
+        out.push_str(&format!("Maximum radius: {max_m} meters.\n"));
+    }
+    out.push('\n');
+
+    out.push_str("## Units\n\n");
+    if let Some(units) = desc["units"].as_object() {
+        for (k, v) in units {
+            if let Some(vs) = v.as_str() {
+                out.push_str(&format!("- `{k}`: {vs}\n"));
+            }
+        }
+    }
+    out.push('\n');
+
+    out.push_str("## Caching\n\n");
+    if let Some(ref_ttl) = desc["caching"]["reference_ttl_seconds"].as_i64() {
+        out.push_str(&format!("- Reference data TTL: {ref_ttl}s\n"));
+    }
+    if let Some(rt_ttl) = desc["caching"]["realtime_ttl_seconds"].as_i64() {
+        out.push_str(&format!("- Real-time data TTL: {rt_ttl}s\n"));
+    }
+    out.push('\n');
+
+    out.push_str("## Enums\n\n");
+    if let Some(enums) = desc["enums"].as_array() {
+        for e in enums {
+            if let Some(name) = e["name"].as_str() {
+                out.push_str(&format!("### {name}\n\n"));
+                if let Some(values) = e["values"].as_array() {
+                    for v in values {
+                        let val = v["value"].as_str().unwrap_or("");
+                        let descr = v["description"].as_str().unwrap_or("");
+                        out.push_str(&format!("- `{val}`: {descr}\n"));
+                    }
+                }
+                out.push('\n');
+            }
+        }
+    }
+
+    out.push_str("## Tools\n\n");
+    if let Some(tools) = desc["tools"].as_array() {
+        for t in tools {
+            let tname = t["name"].as_str().unwrap_or("");
+            let summary = t["summary"].as_str().unwrap_or("");
+            out.push_str(&format!("### `{tname}`\n\n"));
+            if !summary.is_empty() {
+                out.push_str(&format!("{summary}\n\n"));
+            }
+            if let Some(when) = t["when_to_use"].as_str() {
+                out.push_str(&format!("**When to use**: {when}\n\n"));
+            }
+            out.push_str("**Input schema**:\n\n");
+            out.push_str("```json\n");
+            out.push_str(&serde_json::to_string_pretty(&t["input_schema"]).unwrap_or_default());
+            out.push_str("\n```\n\n");
+        }
+    }
+
+    out.push_str("## Resources\n\n");
+    if let Some(resources) = desc["resources"].as_array() {
+        for r in resources {
+            let uri = r["uri"].as_str().unwrap_or("");
+            let rname = r["name"].as_str().unwrap_or("");
+            let rdesc = r["description"].as_str().unwrap_or("");
+            out.push_str(&format!("- `{uri}` — **{rname}**: {rdesc}\n"));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("## Error codes\n\n");
+    if let Some(codes) = desc["error_codes"].as_array() {
+        for c in codes {
+            let code = c["code"].as_i64().unwrap_or(0);
+            let cname = c["name"].as_str().unwrap_or("");
+            let meaning = c["meaning"].as_str().unwrap_or("");
+            out.push_str(&format!("- `{code}` ({cname}): {meaning}\n"));
+        }
+    }
+    out.push('\n');
+
+    out
+}
+
+fn enums() -> Value {
+    json!([
+        {
+            "name": "StationStatus",
+            "description": "Operational state of a Velib station",
+            "values": [
+                {"value": "OPEN", "description": "Station accepts rentals and returns."},
+                {"value": "CLOSED", "description": "Station is out of service."},
+                {"value": "MAINTENANCE", "description": "Station is physically installed but not currently renting or returning bikes."}
+            ]
+        },
+        {
+            "name": "DataFreshness",
+            "description": "Age bucket of the real-time snapshot for a station.",
+            "values": [
+                {"value": "Fresh", "description": "Less than 10 minutes old."},
+                {"value": "Recent", "description": "Between 10 and 30 minutes old."},
+                {"value": "Stale", "description": "Between 30 and 120 minutes old."},
+                {"value": "VeryStale", "description": "More than 120 minutes old."}
+            ]
+        },
+        {
+            "name": "BikeTypeFilter",
+            "description": "Filter bikes by propulsion type.",
+            "values": [
+                {"value": "mechanical", "description": "Only mechanical (non-electric) bikes."},
+                {"value": "electric", "description": "Only electric-assist bikes."},
+                {"value": "any", "description": "Any bike type (default)."}
+            ]
+        }
+    ])
+}
+
+fn tools_with_schemas() -> Value {
+    let defs = tool_definitions();
+    let mut out = Vec::with_capacity(defs.len());
+    for def in &defs {
+        let name = def["name"].as_str().unwrap_or("").to_string();
+        let description = def["description"].as_str().unwrap_or("").to_string();
+        let input_schema = def["inputSchema"].clone();
+        let (when_to_use, output_schema, example_request, example_response, error_codes) =
+            tool_metadata(&name);
+        out.push(json!({
+            "name": name,
+            "summary": description,
+            "when_to_use": when_to_use,
+            "input_schema": input_schema,
+            "output_schema": output_schema,
+            "example_request": example_request,
+            "example_response": example_response,
+            "error_codes": error_codes
+        }));
+    }
+    Value::Array(out)
+}
+
+fn tool_metadata(name: &str) -> (Value, Value, Value, Value, Value) {
+    match name {
+        "find_nearby_stations" => (
+            json!("Given a user location, list nearby stations with distances and real-time availability."),
+            json!({
+                "type": "object",
+                "properties": {
+                    "stations": {"type": "array", "items": {"type": "object"}},
+                    "search_metadata": {"type": "object"}
+                },
+                "required": ["stations", "search_metadata"]
+            }),
+            json!({
+                "latitude": 48.8566,
+                "longitude": 2.3522,
+                "radius_meters": 500,
+                "limit": 5
+            }),
+            json!({
+                "stations": [],
+                "search_metadata": {
+                    "query_point": {"latitude": 48.8566, "longitude": 2.3522},
+                    "radius_meters": 500,
+                    "total_found": 0,
+                    "search_time_ms": 12
+                }
+            }),
+            json!([-32602, -32001]),
+        ),
+        "get_station_by_code" => (
+            json!("Look up a single station by its canonical station code."),
+            json!({
+                "type": "object",
+                "properties": {
+                    "station": {"type": ["object", "null"]},
+                    "found": {"type": "boolean"}
+                },
+                "required": ["station", "found"]
+            }),
+            json!({"station_code": "16107", "include_real_time": true}),
+            json!({"station": null, "found": false}),
+            json!([-32600, -32602, -32001]),
+        ),
+        "search_stations_by_name" => (
+            json!("Search stations by (possibly fuzzy) name when the user refers to a station by label rather than coordinates."),
+            json!({
+                "type": "object",
+                "properties": {
+                    "stations": {"type": "array"},
+                    "search_metadata": {"type": "object"}
+                },
+                "required": ["stations", "search_metadata"]
+            }),
+            json!({"query": "châtelet", "limit": 5, "fuzzy": true}),
+            json!({
+                "stations": [],
+                "search_metadata": {
+                    "query": "châtelet",
+                    "total_found": 0,
+                    "fuzzy_enabled": true,
+                    "search_time_ms": 8
+                }
+            }),
+            json!([-32602, -32001]),
+        ),
+        "get_area_statistics" => (
+            json!("Aggregate bike and dock availability over a rectangular geographic region."),
+            json!({
+                "type": "object",
+                "properties": {
+                    "area_stats": {"type": "object"},
+                    "bounds": {"type": "object"}
+                },
+                "required": ["area_stats", "bounds"]
+            }),
+            json!({
+                "bounds": {"north": 48.87, "south": 48.85, "east": 2.36, "west": 2.34},
+                "include_real_time": true
+            }),
+            json!({
+                "area_stats": {
+                    "total_stations": 0,
+                    "operational_stations": 0,
+                    "total_capacity": 0,
+                    "available_bikes": {"mechanical": 0, "electric": 0, "total": 0},
+                    "available_docks": 0,
+                    "occupancy_rate": 0.0
+                },
+                "bounds": {"north": 48.87, "south": 48.85, "east": 2.36, "west": 2.34}
+            }),
+            json!([-32602, -32001]),
+        ),
+        "plan_bike_journey" => (
+            json!("Propose pickup and drop-off station pairs for a bike trip between two points."),
+            json!({
+                "type": "object",
+                "properties": {
+                    "journey": {"type": "object"}
+                },
+                "required": ["journey"]
+            }),
+            json!({
+                "origin": {"latitude": 48.8566, "longitude": 2.3522},
+                "destination": {"latitude": 48.8606, "longitude": 2.3376}
+            }),
+            json!({
+                "journey": {
+                    "pickup_stations": [],
+                    "dropoff_stations": [],
+                    "recommendations": []
+                }
+            }),
+            json!([-32602, -32001]),
+        ),
+        "describe_api" => (
+            json!("Call once at session start so the agent knows every tool, every enum, and every error code without reading source."),
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "type": {"type": "string", "enum": ["text"]},
+                                "text": {"type": "string"}
+                            }
+                        }
+                    }
+                }
+            }),
+            json!({"format": "json"}),
+            json!({"content": [{"type": "text", "text": "{...api description...}"}]}),
+            json!([-32602]),
+        ),
+        _ => (
+            Value::Null,
+            Value::Null,
+            Value::Null,
+            Value::Null,
+            Value::Array(vec![]),
+        ),
+    }
+}
+
+fn resources() -> Value {
+    json!([
+        {
+            "uri": "velib://stations/reference",
+            "name": "Velib Station Reference Data",
+            "description": "Complete catalog of Velib stations with static metadata.",
+            "mime_type": "application/json",
+            "freshness": "reference"
+        },
+        {
+            "uri": "velib://stations/realtime",
+            "name": "Velib Real-time Availability",
+            "description": "Current bike and dock availability for all stations.",
+            "mime_type": "application/json",
+            "freshness": "realtime"
+        },
+        {
+            "uri": "velib://stations/complete",
+            "name": "Velib Complete Station Data",
+            "description": "Combined reference and real-time data for all stations.",
+            "mime_type": "application/json",
+            "freshness": "realtime"
+        },
+        {
+            "uri": "velib://health",
+            "name": "Service Health Status",
+            "description": "System health and data source status information.",
+            "mime_type": "application/json",
+            "freshness": "realtime"
+        },
+        {
+            "uri": "velib://api/description",
+            "name": "Velib MCP API Self-Description",
+            "description": "Machine-readable description of this MCP API.",
+            "mime_type": "application/json",
+            "freshness": "static"
+        }
+    ])
+}
+
+fn error_codes() -> Value {
+    json!([
+        {"code": -32700, "name": "parse_error", "meaning": "Invalid JSON was received by the server."},
+        {"code": -32600, "name": "invalid_request", "meaning": "The JSON sent is not a valid request; also used for station_not_found."},
+        {"code": -32601, "name": "method_not_found", "meaning": "The requested JSON-RPC method does not exist."},
+        {"code": -32602, "name": "invalid_params", "meaning": "Invalid method parameters: bad coordinates, outside service area, search radius too large, result limit exceeded, or validation failure."},
+        {"code": -32603, "name": "internal_error", "meaning": "Server-side error: MCP protocol issue, cache failure, or unclassified internal error."},
+        {"code": -32001, "name": "server_error", "meaning": "Upstream error: HTTP failure talking to Paris Open Data, including rate limiting (HTTP 429)."}
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn description_has_expected_top_level_keys() {
+        let desc = api_description();
+        for key in [
+            "server",
+            "service_area",
+            "units",
+            "caching",
+            "enums",
+            "tools",
+            "resources",
+            "error_codes",
+        ] {
+            assert!(desc.get(key).is_some(), "missing top-level key: {key}");
+        }
+    }
+
+    #[test]
+    fn caching_ttls_reflect_imported_constants() {
+        let desc = api_description();
+        assert_eq!(
+            desc["caching"]["reference_ttl_seconds"].as_i64(),
+            Some(REFERENCE_CACHE_TTL_MINUTES * 60)
+        );
+        assert_eq!(
+            desc["caching"]["realtime_ttl_seconds"].as_i64(),
+            Some(REALTIME_CACHE_TTL_MINUTES * 60)
+        );
+    }
+
+    #[test]
+    fn markdown_starts_with_h1_and_mentions_tools() {
+        let md = api_description_markdown();
+        assert!(md.starts_with("# "), "markdown must start with `# `");
+        for tool in [
+            "find_nearby_stations",
+            "get_station_by_code",
+            "search_stations_by_name",
+            "get_area_statistics",
+            "plan_bike_journey",
+            "describe_api",
+        ] {
+            assert!(md.contains(tool), "markdown missing tool {tool}");
+        }
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,3 +1,4 @@
+pub mod describe;
 pub mod handlers;
 pub mod server;
 pub mod types;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -222,98 +222,7 @@ impl McpServer {
         request: JsonRpcRequest,
     ) -> Result<JsonRpcResponse> {
         let result = match request.method.as_str() {
-            "tools/list" => Ok(json!({
-                "tools": [
-                    {
-                        "name": "find_nearby_stations",
-                        "description": "Find Velib stations within a radius of coordinates",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "latitude": {"type": "number", "minimum": 48.7, "maximum": 49.0},
-                                "longitude": {"type": "number", "minimum": 2.0, "maximum": 2.6},
-                                "radius_meters": {"type": "integer", "minimum": 100, "maximum": 5000, "default": 500},
-                                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 10},
-                                "availability_filter": {"type": "object"}
-                            },
-                            "required": ["latitude", "longitude"]
-                        }
-                    },
-                    {
-                        "name": "get_station_by_code",
-                        "description": "Get detailed information about a specific station",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "station_code": {"type": "string"},
-                                "include_real_time": {"type": "boolean", "default": true}
-                            },
-                            "required": ["station_code"]
-                        }
-                    },
-                    {
-                        "name": "search_stations_by_name",
-                        "description": "Search stations by name with optional fuzzy matching",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "query": {"type": "string", "minLength": 2},
-                                "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
-                                "fuzzy": {"type": "boolean", "default": true}
-                            },
-                            "required": ["query"]
-                        }
-                    },
-                    {
-                        "name": "get_area_statistics",
-                        "description": "Get aggregated statistics for a geographic area",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "bounds": {
-                                    "type": "object",
-                                    "properties": {
-                                        "north": {"type": "number"},
-                                        "south": {"type": "number"},
-                                        "east": {"type": "number"},
-                                        "west": {"type": "number"}
-                                    },
-                                    "required": ["north", "south", "east", "west"]
-                                },
-                                "include_real_time": {"type": "boolean", "default": true}
-                            },
-                            "required": ["bounds"]
-                        }
-                    },
-                    {
-                        "name": "plan_bike_journey",
-                        "description": "Plan a bike journey with pickup and dropoff suggestions",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "origin": {
-                                    "type": "object",
-                                    "properties": {
-                                        "latitude": {"type": "number"},
-                                        "longitude": {"type": "number"}
-                                    },
-                                    "required": ["latitude", "longitude"]
-                                },
-                                "destination": {
-                                    "type": "object",
-                                    "properties": {
-                                        "latitude": {"type": "number"},
-                                        "longitude": {"type": "number"}
-                                    },
-                                    "required": ["latitude", "longitude"]
-                                },
-                                "preferences": {"type": "object"}
-                            },
-                            "required": ["origin", "destination"]
-                        }
-                    }
-                ]
-            })),
+            "tools/list" => Ok(json!({ "tools": tool_definitions() })),
             "tools/call" => {
                 let params = request
                     .params
@@ -346,6 +255,7 @@ impl McpServer {
                     "plan_bike_journey" => {
                         tool_text_content(arguments, |input| handler.plan_bike_journey(input)).await
                     }
+                    "describe_api" => describe_api_tool_response(arguments),
                     _ => Err(Error::McpProtocol(format!("Unknown tool: {tool_name}"))),
                 }
             }
@@ -374,9 +284,42 @@ impl McpServer {
                         "name": "Service Health Status",
                         "description": "System health and data source status information",
                         "mimeType": "application/json"
+                    },
+                    {
+                        "uri": "velib://api/description",
+                        "name": "Velib MCP API Self-Description",
+                        "description": "Machine-readable description of the MCP API: server info, \
+                                        service area, units, cache TTLs, enum definitions, per-tool \
+                                        schemas, and error codes. Static; safe to cache indefinitely \
+                                        within a server version.",
+                        "mimeType": "application/json"
                     }
                 ]
             })),
+            "resources/read" => {
+                let params = request
+                    .params
+                    .as_object()
+                    .ok_or_else(|| Error::McpProtocol("Invalid params".to_string()))?;
+                let uri = params
+                    .get("uri")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| Error::McpProtocol("Missing resource uri".to_string()))?;
+                match uri {
+                    "velib://api/description" => Ok(json!({
+                        "contents": [
+                            {
+                                "uri": uri,
+                                "mimeType": "application/json",
+                                "text": serde_json::to_string_pretty(
+                                    &super::describe::api_description()
+                                )?
+                            }
+                        ]
+                    })),
+                    _ => Err(Error::McpProtocol(format!("Unknown resource uri: {uri}"))),
+                }
+            }
             _ => Err(Error::McpProtocol(format!(
                 "Unknown method: {}",
                 request.method
@@ -398,6 +341,149 @@ impl McpServer {
             }),
         }
     }
+}
+
+/// Canonical list of tool definitions served by `tools/list` and re-used by
+/// [`crate::mcp::describe::api_description`] so the schema surface cannot drift
+/// between the JSON-RPC endpoint and the self-documentation payload.
+#[must_use]
+pub fn tool_definitions() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "find_nearby_stations",
+            "description": "Find Velib stations within a radius of coordinates",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "latitude": {"type": "number", "minimum": 48.7, "maximum": 49.0},
+                    "longitude": {"type": "number", "minimum": 2.0, "maximum": 2.6},
+                    "radius_meters": {"type": "integer", "minimum": 100, "maximum": 5000, "default": 500},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 10},
+                    "availability_filter": {"type": "object"}
+                },
+                "required": ["latitude", "longitude"]
+            }
+        }),
+        json!({
+            "name": "get_station_by_code",
+            "description": "Get detailed information about a specific station",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "station_code": {"type": "string"},
+                    "include_real_time": {"type": "boolean", "default": true}
+                },
+                "required": ["station_code"]
+            }
+        }),
+        json!({
+            "name": "search_stations_by_name",
+            "description": "Search stations by name with optional fuzzy matching",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "minLength": 2},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+                    "fuzzy": {"type": "boolean", "default": true}
+                },
+                "required": ["query"]
+            }
+        }),
+        json!({
+            "name": "get_area_statistics",
+            "description": "Get aggregated statistics for a geographic area",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "bounds": {
+                        "type": "object",
+                        "properties": {
+                            "north": {"type": "number"},
+                            "south": {"type": "number"},
+                            "east": {"type": "number"},
+                            "west": {"type": "number"}
+                        },
+                        "required": ["north", "south", "east", "west"]
+                    },
+                    "include_real_time": {"type": "boolean", "default": true}
+                },
+                "required": ["bounds"]
+            }
+        }),
+        json!({
+            "name": "plan_bike_journey",
+            "description": "Plan a bike journey with pickup and dropoff suggestions",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "origin": {
+                        "type": "object",
+                        "properties": {
+                            "latitude": {"type": "number"},
+                            "longitude": {"type": "number"}
+                        },
+                        "required": ["latitude", "longitude"]
+                    },
+                    "destination": {
+                        "type": "object",
+                        "properties": {
+                            "latitude": {"type": "number"},
+                            "longitude": {"type": "number"}
+                        },
+                        "required": ["latitude", "longitude"]
+                    },
+                    "preferences": {"type": "object"}
+                },
+                "required": ["origin", "destination"]
+            }
+        }),
+        json!({
+            "name": "describe_api",
+            "description": "Return a machine-readable description of this MCP API: server info, \
+                            service area, units, cache TTLs, enum definitions, per-tool schemas, \
+                            and error codes. Default format is JSON; pass format=\"markdown\" for \
+                            a human-readable rendering. Zero I/O.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json"
+                    }
+                },
+                "additionalProperties": false,
+                "required": []
+            }
+        }),
+    ]
+}
+
+/// Handle a `tools/call` for `describe_api`. Zero network I/O; the payload is
+/// produced entirely from compile-time constants and hard-coded metadata in
+/// [`crate::mcp::describe`].
+fn describe_api_tool_response(arguments: &Value) -> Result<Value> {
+    let format = arguments
+        .get("format")
+        .and_then(|v| v.as_str())
+        .unwrap_or("json");
+    let text = match format {
+        "json" => serde_json::to_string_pretty(&super::describe::api_description())?,
+        "markdown" => super::describe::api_description_markdown(),
+        other => {
+            return Err(Error::Validation(format!(
+                "unsupported format {other:?}; expected \"json\" or \"markdown\""
+            )));
+        }
+    };
+    Ok(json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text,
+            }
+        ]
+    }))
 }
 
 /// Deserialize `arguments` into the input type expected by `call`, invoke it,
@@ -464,6 +550,7 @@ async fn handle_resource(
             Ok(response) => Json(response).into_response(),
             Err(e) => resource_error(e, "Failed to fetch health status"),
         },
+        "velib://api/description" => Json(super::describe::api_description()).into_response(),
         _ => (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "Resource not found"})),

--- a/tests/mcp_describe_tests.rs
+++ b/tests/mcp_describe_tests.rs
@@ -1,0 +1,307 @@
+//! End-to-end and drift-guard tests for the `describe_api` self-documentation
+//! endpoint.
+//!
+//! These tests cover the five reviewer-required guarantees from issue #9:
+//!
+//! 1. The describe payload is exposed both as an MCP tool (`describe_api`)
+//!    and as an MCP resource (`velib://api/description`).
+//! 2. Cache TTLs come from the imported constants in `data::client` and are
+//!    never duplicated inside the describe module (asserted indirectly via
+//!    the constant-import test in `src/mcp/describe.rs` plus the value check
+//!    below).
+//! 3. Enum-variant drift guard: every value listed in
+//!    `api_description().enums[*].values[*]` round-trips through the
+//!    corresponding Rust enum's `Deserialize` impl.
+//! 4. Schema-parity guard: for every tool returned by `tools/list`, the
+//!    describe payload's `tools[*].input_schema` equals the `inputSchema`
+//!    served by `tools/list` (byte-for-byte `serde_json::Value` equality).
+//! 5. Markdown output: non-empty, starts with `# `, and names every tool.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use velib_mcp::data::client::{REALTIME_CACHE_TTL_MINUTES, REFERENCE_CACHE_TTL_MINUTES};
+use velib_mcp::mcp::describe::{api_description, api_description_markdown};
+use velib_mcp::mcp::server::McpServer;
+use velib_mcp::types::{BikeTypeFilter, DataFreshness, StationStatus};
+
+async fn post_mcp(body: Value) -> (StatusCode, Value) {
+    let router = McpServer::new().router();
+    let request = Request::builder()
+        .uri("/mcp")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+#[test]
+fn description_has_expected_top_level_shape() {
+    let desc = api_description();
+    for key in [
+        "server",
+        "service_area",
+        "units",
+        "caching",
+        "enums",
+        "tools",
+        "resources",
+        "error_codes",
+    ] {
+        assert!(
+            desc.get(key).is_some(),
+            "describe_api payload missing top-level key `{key}`"
+        );
+    }
+
+    // Cache TTLs must match the imported constants converted from minutes to
+    // seconds (reviewer revision 2: no duplicate values).
+    assert_eq!(
+        desc["caching"]["reference_ttl_seconds"].as_i64(),
+        Some(REFERENCE_CACHE_TTL_MINUTES * 60),
+        "reference TTL must be sourced from data::client::REFERENCE_CACHE_TTL_MINUTES"
+    );
+    assert_eq!(
+        desc["caching"]["realtime_ttl_seconds"].as_i64(),
+        Some(REALTIME_CACHE_TTL_MINUTES * 60),
+        "realtime TTL must be sourced from data::client::REALTIME_CACHE_TTL_MINUTES"
+    );
+}
+
+#[tokio::test]
+async fn describe_api_tool_is_registered_and_callable() {
+    // Tool must appear in tools/list with the documented input schema.
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    }))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let tools = body["result"]["tools"].as_array().unwrap();
+    let describe = tools
+        .iter()
+        .find(|t| t["name"] == "describe_api")
+        .expect("describe_api tool missing from tools/list");
+    assert_eq!(describe["inputSchema"]["type"], "object");
+    assert_eq!(
+        describe["inputSchema"]["properties"]["format"]["enum"],
+        json!(["json", "markdown"])
+    );
+    assert_eq!(
+        describe["inputSchema"]["additionalProperties"],
+        json!(false)
+    );
+
+    // Calling the tool returns the documented content envelope with JSON text.
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": "describe_api", "arguments": {"format": "json"}}
+    }))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let text = body["result"]["content"][0]["text"]
+        .as_str()
+        .expect("describe_api tool response missing text content");
+    let parsed: Value = serde_json::from_str(text).expect("describe_api returned invalid JSON");
+    assert!(parsed["tools"].is_array());
+}
+
+#[tokio::test]
+async fn describe_api_resource_is_registered_and_readable() {
+    // Reviewer revision 1: the description must be exposed as a resource too.
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "resources/list",
+        "params": {}
+    }))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let resources = body["result"]["resources"].as_array().unwrap();
+    let api_resource = resources
+        .iter()
+        .find(|r| r["uri"] == "velib://api/description")
+        .expect("velib://api/description not listed in resources/list");
+    assert_eq!(api_resource["mimeType"], "application/json");
+    assert!(api_resource["name"].is_string());
+    assert!(api_resource["description"].is_string());
+
+    // resources/read returns the JSON description as text content.
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "resources/read",
+        "params": {"uri": "velib://api/description"}
+    }))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let contents = body["result"]["contents"].as_array().unwrap();
+    assert_eq!(contents[0]["uri"], "velib://api/description");
+    assert_eq!(contents[0]["mimeType"], "application/json");
+    let text = contents[0]["text"].as_str().unwrap();
+    let parsed: Value = serde_json::from_str(text).unwrap();
+    assert!(parsed["server"]["name"].is_string());
+}
+
+#[tokio::test]
+async fn describe_api_markdown_format_is_well_formed() {
+    // Reviewer revision 5: markdown output is non-empty, starts with `# `,
+    // and contains every tool name at least once.
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "describe_api", "arguments": {"format": "markdown"}}
+    }))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let text = body["result"]["content"][0]["text"].as_str().unwrap();
+
+    assert!(!text.is_empty(), "markdown output must be non-empty");
+    assert!(text.starts_with("# "), "markdown must start with `# `");
+    for tool in [
+        "find_nearby_stations",
+        "get_station_by_code",
+        "search_stations_by_name",
+        "get_area_statistics",
+        "plan_bike_journey",
+        "describe_api",
+    ] {
+        assert!(
+            text.contains(tool),
+            "markdown output missing tool name `{tool}`"
+        );
+    }
+
+    // Also test the helper directly so the failure surface is clear when the
+    // renderer regresses independently of the JSON-RPC plumbing.
+    let direct = api_description_markdown();
+    assert!(direct.starts_with("# "));
+    assert!(direct.contains("describe_api"));
+}
+
+#[tokio::test]
+async fn schema_parity_between_tools_list_and_describe_payload() {
+    // Reviewer revision 4: every tool's inputSchema in tools/list must equal
+    // the tools[*].input_schema served by describe_api.
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    }))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let mut tools_list_schemas: std::collections::HashMap<String, Value> =
+        std::collections::HashMap::new();
+    for tool in body["result"]["tools"].as_array().unwrap() {
+        let name = tool["name"].as_str().unwrap().to_string();
+        tools_list_schemas.insert(name, tool["inputSchema"].clone());
+    }
+
+    let desc = api_description();
+    let describe_tools = desc["tools"].as_array().unwrap();
+    assert_eq!(
+        describe_tools.len(),
+        tools_list_schemas.len(),
+        "describe_api tool count must match tools/list"
+    );
+
+    for tool in describe_tools {
+        let name = tool["name"].as_str().unwrap();
+        let expected = tools_list_schemas
+            .get(name)
+            .unwrap_or_else(|| panic!("tool `{name}` in describe payload not in tools/list"));
+        assert_eq!(
+            &tool["input_schema"], expected,
+            "input_schema drift for tool `{name}`"
+        );
+    }
+}
+
+#[test]
+fn enum_variant_drift_guard_matches_rust_types() {
+    // Reviewer revision 3: every value listed in the describe payload's enums
+    // must deserialize into the corresponding Rust enum. Missing enum types
+    // skip gracefully.
+    let desc = api_description();
+    let enums = desc["enums"].as_array().expect("enums array");
+
+    for enum_block in enums {
+        let name = enum_block["name"].as_str().expect("enum name");
+        let values = enum_block["values"].as_array().expect("enum values");
+
+        match name {
+            "StationStatus" => {
+                for v in values {
+                    let raw = v["value"].as_str().unwrap();
+                    let json_value = Value::String(raw.to_string());
+                    let parsed: std::result::Result<StationStatus, _> =
+                        serde_json::from_value(json_value);
+                    assert!(
+                        parsed.is_ok(),
+                        "StationStatus documented value `{raw}` does not round-trip: {parsed:?}"
+                    );
+                }
+            }
+            "DataFreshness" => {
+                for v in values {
+                    let raw = v["value"].as_str().unwrap();
+                    let json_value = Value::String(raw.to_string());
+                    let parsed: std::result::Result<DataFreshness, _> =
+                        serde_json::from_value(json_value);
+                    assert!(
+                        parsed.is_ok(),
+                        "DataFreshness documented value `{raw}` does not round-trip: {parsed:?}"
+                    );
+                }
+            }
+            "BikeTypeFilter" => {
+                for v in values {
+                    let raw = v["value"].as_str().unwrap();
+                    let json_value = Value::String(raw.to_string());
+                    let parsed: std::result::Result<BikeTypeFilter, _> =
+                        serde_json::from_value(json_value);
+                    assert!(
+                        parsed.is_ok(),
+                        "BikeTypeFilter documented value `{raw}` does not round-trip: {parsed:?}"
+                    );
+                }
+            }
+            // Skip gracefully for any enum we don't know about (plan: "if the
+            // variants don't exist, skip gracefully").
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn describe_api_rejects_unknown_format() {
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "describe_api", "arguments": {"format": "yaml"}}
+    }))
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["error"].is_object(),
+        "unsupported format must produce a JSON-RPC error"
+    );
+}

--- a/tests/mcp_server_routing_tests.rs
+++ b/tests/mcp_server_routing_tests.rs
@@ -69,7 +69,7 @@ async fn get_resource(uri: &str) -> (StatusCode, Value) {
 }
 
 #[tokio::test]
-async fn tools_list_returns_all_five_tools() {
+async fn tools_list_returns_all_tools() {
     let (status, body) = post_mcp(json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -88,7 +88,8 @@ async fn tools_list_returns_all_five_tools() {
     assert!(names.contains(&"search_stations_by_name"));
     assert!(names.contains(&"get_area_statistics"));
     assert!(names.contains(&"plan_bike_journey"));
-    assert_eq!(tools.len(), 5);
+    assert!(names.contains(&"describe_api"));
+    assert_eq!(tools.len(), 6);
 }
 
 #[tokio::test]
@@ -111,7 +112,7 @@ async fn tools_list_entries_have_required_schema_fields() {
 }
 
 #[tokio::test]
-async fn resources_list_returns_four_resources() {
+async fn resources_list_returns_all_resources() {
     let (status, body) = post_mcp(json!({
         "jsonrpc": "2.0",
         "id": 7,
@@ -132,7 +133,8 @@ async fn resources_list_returns_four_resources() {
     assert!(uris.contains(&"velib://stations/realtime"));
     assert!(uris.contains(&"velib://stations/complete"));
     assert!(uris.contains(&"velib://health"));
-    assert_eq!(resources.len(), 4);
+    assert!(uris.contains(&"velib://api/description"));
+    assert_eq!(resources.len(), 5);
     for resource in resources {
         assert_eq!(resource["mimeType"], "application/json");
         assert!(resource["name"].is_string());


### PR DESCRIPTION
Closes #9.

## Summary

Adds a self-documentation endpoint so MCP clients (LLMs) can discover the server schema at runtime: server info, service area, units for numerical values, per-data-class cache TTLs, all enum values with definitions, per-tool input/output schemas, and JSON-RPC error codes.

Exposed both as:
- **Tool** `describe_api` — optional `format: "json" | "markdown"` (default `json`).
- **Resource** `velib://api/description` — idiomatic MCP discovery path.

Payload imports TTL constants directly from `data::client` (promoted to `pub const`) so the docs cannot silently drift from the cache behavior.

## Drift guards (tests in `tests/mcp_describe_tests.rs`)

- Schema-parity: every tool exposed by `tools/list` has a matching entry in `describe_api.tools[*]` with identical `input_schema` (shared source via `tool_definitions()`).
- Enum-variant drift: iterates documented enum values and round-trips each through the corresponding Rust enum (`StationStatus`, `DataFreshness`, etc.).
- Markdown content: non-empty, starts with `# `, and mentions every tool name.
- Unknown `format` argument is rejected.
- Top-level shape: required keys present.

## Out of scope

- No new dependencies (no `insta`, no `criterion`).
- No behavioral changes to existing endpoints.

## Test plan

- [x] `cargo test` — 123 passed, 0 failed, 8 ignored (pre-existing network-gated).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [ ] CI green on this PR (will confirm once checks run).

## Agent-job metadata (for janitor dedup)

- job-id: `cron-2026-04-21-one_track-2`
- oldest-issue-id: `one_track#2`
- this-issue: `velib-mcp#9`
- last-commit-sha: `409def906a84844507395dca131af2fe951b2826`

Per cron policy, this PR is **draft** and is NOT marked `ready-for-review` — planner jobs never promote. The janitor decides promotion.
