### PR TITLE
Tighten JSON-RPC, cover parsers + aggregation, refresh stale docs

### DIFF
--- a/docs/context/etat_actuel.md
+++ b/docs/context/etat_actuel.md
@@ -1,41 +1,36 @@
 # État Actuel du Projet Velib MCP
 
-## Phase Actuelle: Phase 2 - Architecture Système
+Dernière mise à jour : 2026-04-23
 
-### Statut: Prêt à commencer
-Date de dernière mise à jour: 2025-06-14
+## Statut global
 
-## Phase 0 - Configuration (TERMINÉE ✅)
-- ✅ Initialisation du projet Rust avec cargo
-- ✅ Configuration git et remote GitHub (DominicBurkart/velib-mcp)
-- ✅ Structure de documentation créée (/docs)
-- ✅ Configuration des hooks pre-commit (fmt, clippy, audit)
-- ✅ Workflow CI/CD GitHub Actions configuré
-- ✅ Dockerfile créé pour déploiement Scaleway (compatible Podman)
-- ✅ Système de suivi de contexte Claude initialisé
-- ✅ Documentation projet et README créés
+Toutes les phases planifiées (0 à 4) sont terminées. Le serveur MCP est
+fonctionnel, déployé via GitHub Actions vers Scaleway, et dispose d'une
+couverture de tests unitaires et d'intégration automatisée.
 
-## Phase 1 - Analyse des Données (TERMINÉE ✅)
-- ✅ Analyse complète du dataset disponibilité temps réel
-- ✅ Analyse complète du dataset emplacements des stations
-- ✅ Identification structure données et colonnes (15+ champs)
-- ✅ Documentation technique détaillée (/docs/api/data_analysis.md)
-- ✅ Schémas de données Rust complets (/docs/api/mcp_schemas.md)
-- ✅ Spécification interfaces MCP avec 5 tools (/docs/api/mcp_interface_spec.md)
+| Phase | Description | Statut |
+|-------|-------------|--------|
+| 0 | Configuration projet, CI/CD, documentation | Terminée |
+| 1 | Analyse des deux jeux de données Velib | Terminée |
+| 2A | Fondation serveur et environnement | Terminée |
+| 2B | Types MCP et protocole JSON-RPC 2.0 | Terminée |
+| 3A | Client données et cache TTL | Terminée |
+| 3B | Handlers MCP connectés aux données live | Terminée |
+| 4 | Nettoyage repo (worktrees committés retirés) | Terminée |
 
-## Prochaines Étapes (Phase 2)
-1. 🎯 Architecturer le système et composants
-2. 🎯 Définir l'organisation modulaire du code Rust
-3. 🎯 Planifier l'approche agile avec PRs cohérentes
-4. 🎯 Documenter l'architecture dans /docs/decisions
+## Interfaces livrées
 
-## Dépendances Techniques
-- Rust (version stable récente)
-- GitHub Actions pour CI/CD
-- Scaleway CLI pour déploiement
-- Podman pour conteneurisation
+- Tools MCP : [`find_nearby_stations`](../../src/mcp/handlers.rs),
+  `get_station_by_code`, `search_stations_by_name`,
+  `get_area_statistics`, `plan_bike_journey`.
+- Resources MCP : `velib://stations/reference`,
+  `velib://stations/realtime`, `velib://stations/complete`,
+  `velib://health`.
+- Transports : HTTP POST `/mcp` et WebSocket `/mcp/ws`
+  (voir [`src/mcp/server.rs`](../../src/mcp/server.rs)).
 
-## Notes Importantes
-- Repository configuré pour github.com/dominicburkart/velib-mcp
-- Email configuré: dominic@dominic.computer
-- Approche TDD requise pour toutes les fonctionnalités
+## Évolutions en cours
+
+Les améliorations itératives (qualité de code, couverture, clarté) sont
+pilotées par PRs individuelles. Voir les issues ouvertes sur GitHub pour
+la priorité actuelle.

--- a/docs/development/project_prompt.md
+++ b/docs/development/project_prompt.md
@@ -1,19 +1,5 @@
 # Projet Claude Code : Serveur MCP Velib
 
-## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP. 
-- **Répertoire de travail** : `~/code/velib-mcp`
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
-
-## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
-
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
-
-**But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
-
-[... rest of the original prompt content ...]
+Ce document a été consolidé dans [`CLAUDE.md`](../../CLAUDE.md) à la racine du
+dépôt. Reportez-vous à ce fichier pour le contexte du projet, les objectifs,
+et le processus de développement.

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -103,7 +103,7 @@ impl VelibDataClient {
             }
 
             for record in records {
-                if let Ok(station) = self.parse_reference_station(record) {
+                if let Ok(station) = parse_reference_station(record) {
                     all_stations.push(station);
                 }
             }
@@ -161,7 +161,7 @@ impl VelibDataClient {
             }
 
             for record in records {
-                if let Ok((station_code, status)) = self.parse_realtime_status(record) {
+                if let Ok((station_code, status)) = parse_realtime_status(record) {
                     all_status.insert(station_code, status);
                 }
             }
@@ -221,98 +221,6 @@ impl VelibDataClient {
             .find(|station| station.reference.station_code == station_code))
     }
 
-    /// Parse reference station data from API response
-    fn parse_reference_station(&self, record: &Value) -> Result<StationReference> {
-        let station_code = record["stationcode"]
-            .as_str()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
-            .to_string();
-
-        let name = record["name"]
-            .as_str()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station name")))?
-            .to_string();
-
-        let capacity = record["capacity"]
-            .as_u64()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing capacity")))?
-            as u16;
-
-        // Parse coordinates from coordonnees_geo
-        let geo_point = record["coordonnees_geo"]
-            .as_object()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing geo coordinates")))?;
-
-        let latitude = geo_point["lat"]
-            .as_f64()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing latitude")))?;
-
-        let longitude = geo_point["lon"]
-            .as_f64()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing longitude")))?;
-
-        let coordinates = crate::types::Coordinates::new(latitude, longitude);
-
-        // Parse service capabilities
-        let capabilities = ServiceCapabilities {
-            accepts_credit_card: false,  // Not available in current API
-            has_charging_station: false, // Not available in current API
-            is_virtual_station: false,   // Not available in current API
-        };
-
-        Ok(StationReference {
-            station_code,
-            name,
-            coordinates,
-            capacity,
-            capabilities,
-        })
-    }
-
-    /// Parse real-time status data from API response
-    fn parse_realtime_status(&self, record: &Value) -> Result<(String, RealTimeStatus)> {
-        let station_code = record["stationcode"]
-            .as_str()
-            .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
-            .to_string();
-
-        let mechanical_bikes = record["mechanical"].as_u64().unwrap_or(0) as u16;
-
-        let electric_bikes = record["ebike"].as_u64().unwrap_or(0) as u16;
-
-        let available_docks = record["numdocksavailable"].as_u64().unwrap_or(0) as u16;
-
-        // Parse status
-        let status_str = record["is_installed"].as_str().unwrap_or("NON");
-
-        let status = match status_str {
-            "OUI" => {
-                let is_renting = record["is_renting"].as_str().unwrap_or("NON") == "OUI";
-                let is_returning = record["is_returning"].as_str().unwrap_or("NON") == "OUI";
-
-                if is_renting && is_returning {
-                    StationStatus::Open
-                } else {
-                    StationStatus::Maintenance
-                }
-            }
-            _ => StationStatus::Closed,
-        };
-
-        // Parse last update time
-        let default_time = Utc::now().to_rfc3339();
-        let last_update_str = record["duedate"].as_str().unwrap_or(&default_time);
-
-        let last_update = DateTime::parse_from_rfc3339(last_update_str)
-            .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
-
-        let bikes = BikeAvailability::new(mechanical_bikes, electric_bikes);
-
-        let real_time_status = RealTimeStatus::new(bikes, available_docks, status, last_update);
-
-        Ok((station_code, real_time_status))
-    }
-
     /// Clean up expired cache entries
     pub async fn cleanup_cache(&self) {
         self.reference_cache.cleanup_expired().await;
@@ -324,5 +232,195 @@ impl VelibDataClient {
         let reference_size = self.reference_cache.size().await;
         let realtime_size = self.realtime_cache.size().await;
         (reference_size, realtime_size)
+    }
+}
+
+/// Parse one reference station record from the Paris Open Data API.
+///
+/// Extracted as a free function (not a method) because it has no dependency
+/// on `VelibDataClient` state. This keeps the parser cheaply testable against
+/// fixture JSON values.
+pub(crate) fn parse_reference_station(record: &Value) -> Result<StationReference> {
+    let station_code = record["stationcode"]
+        .as_str()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
+        .to_string();
+
+    let name = record["name"]
+        .as_str()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station name")))?
+        .to_string();
+
+    let capacity = record["capacity"]
+        .as_u64()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing capacity")))?
+        as u16;
+
+    let geo_point = record["coordonnees_geo"]
+        .as_object()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing geo coordinates")))?;
+
+    let latitude = geo_point["lat"]
+        .as_f64()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing latitude")))?;
+
+    let longitude = geo_point["lon"]
+        .as_f64()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing longitude")))?;
+
+    Ok(StationReference {
+        station_code,
+        name,
+        coordinates: crate::types::Coordinates::new(latitude, longitude),
+        capacity,
+        // The Paris Open Data stations dataset does not expose these fields.
+        capabilities: ServiceCapabilities::default(),
+    })
+}
+
+/// Parse one real-time status record from the Paris Open Data API.
+///
+/// Returns the station code alongside the parsed status so callers can index
+/// the result by code. Missing bike/dock counts are coerced to 0 rather than
+/// failing the row -- this matches how the upstream API sometimes omits fields
+/// for stations temporarily out of service.
+pub(crate) fn parse_realtime_status(record: &Value) -> Result<(String, RealTimeStatus)> {
+    let station_code = record["stationcode"]
+        .as_str()
+        .ok_or_else(|| Error::Internal(anyhow::anyhow!("Missing station code")))?
+        .to_string();
+
+    let mechanical_bikes = record["mechanical"].as_u64().unwrap_or(0) as u16;
+    let electric_bikes = record["ebike"].as_u64().unwrap_or(0) as u16;
+    let available_docks = record["numdocksavailable"].as_u64().unwrap_or(0) as u16;
+
+    let status = match record["is_installed"].as_str().unwrap_or("NON") {
+        "OUI" => {
+            let is_renting = record["is_renting"].as_str().unwrap_or("NON") == "OUI";
+            let is_returning = record["is_returning"].as_str().unwrap_or("NON") == "OUI";
+            if is_renting && is_returning {
+                StationStatus::Open
+            } else {
+                StationStatus::Maintenance
+            }
+        }
+        _ => StationStatus::Closed,
+    };
+
+    let last_update = record["duedate"]
+        .as_str()
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map_or_else(Utc::now, |dt| dt.with_timezone(&Utc));
+
+    Ok((
+        station_code,
+        RealTimeStatus::new(
+            BikeAvailability::new(mechanical_bikes, electric_bikes),
+            available_docks,
+            status,
+            last_update,
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fixture_reference() -> Value {
+        json!({
+            "stationcode": "16107",
+            "name": "Benjamin Godard - Victor Hugo",
+            "capacity": 35,
+            "coordonnees_geo": { "lat": 48.8656, "lon": 2.2779 }
+        })
+    }
+
+    #[test]
+    fn parse_reference_station_happy_path() {
+        let station = parse_reference_station(&fixture_reference()).expect("parses");
+        assert_eq!(station.station_code, "16107");
+        assert_eq!(station.name, "Benjamin Godard - Victor Hugo");
+        assert_eq!(station.capacity, 35);
+        assert!((station.coordinates.latitude - 48.8656).abs() < 1e-9);
+        assert!((station.coordinates.longitude - 2.2779).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_reference_station_rejects_missing_fields() {
+        let cases = [
+            json!({"name": "x", "capacity": 10, "coordonnees_geo": {"lat": 48.85, "lon": 2.35}}),
+            json!({"stationcode": "1", "capacity": 10, "coordonnees_geo": {"lat": 48.85, "lon": 2.35}}),
+            json!({"stationcode": "1", "name": "x", "coordonnees_geo": {"lat": 48.85, "lon": 2.35}}),
+            json!({"stationcode": "1", "name": "x", "capacity": 10}),
+        ];
+        for bad in cases {
+            assert!(parse_reference_station(&bad).is_err(), "bad={bad}");
+        }
+    }
+
+    #[test]
+    fn parse_realtime_status_maps_renting_returning_to_open() {
+        let record = json!({
+            "stationcode": "16107",
+            "mechanical": 5,
+            "ebike": 3,
+            "numdocksavailable": 12,
+            "is_installed": "OUI",
+            "is_renting": "OUI",
+            "is_returning": "OUI",
+            "duedate": "2026-04-23T10:00:00+00:00"
+        });
+        let (code, status) = parse_realtime_status(&record).expect("parses");
+        assert_eq!(code, "16107");
+        assert_eq!(status.bikes.mechanical, 5);
+        assert_eq!(status.bikes.electric, 3);
+        assert_eq!(status.available_docks, 12);
+        assert_eq!(status.status, StationStatus::Open);
+    }
+
+    #[test]
+    fn parse_realtime_status_installed_but_not_renting_is_maintenance() {
+        let record = json!({
+            "stationcode": "1",
+            "is_installed": "OUI",
+            "is_renting": "NON",
+            "is_returning": "OUI",
+        });
+        let (_, status) = parse_realtime_status(&record).expect("parses");
+        assert_eq!(status.status, StationStatus::Maintenance);
+    }
+
+    #[test]
+    fn parse_realtime_status_uninstalled_is_closed() {
+        let record = json!({
+            "stationcode": "1",
+            "is_installed": "NON",
+        });
+        let (_, status) = parse_realtime_status(&record).expect("parses");
+        assert_eq!(status.status, StationStatus::Closed);
+    }
+
+    #[test]
+    fn parse_realtime_status_missing_counts_default_to_zero() {
+        // Matches upstream behavior: stations temporarily missing mechanical/ebike/
+        // numdocksavailable fields should not fail the whole batch.
+        let record = json!({
+            "stationcode": "1",
+            "is_installed": "OUI",
+            "is_renting": "OUI",
+            "is_returning": "OUI",
+        });
+        let (_, status) = parse_realtime_status(&record).expect("parses");
+        assert_eq!(status.bikes.mechanical, 0);
+        assert_eq!(status.bikes.electric, 0);
+        assert_eq!(status.available_docks, 0);
+    }
+
+    #[test]
+    fn parse_realtime_status_rejects_missing_station_code() {
+        let record = json!({"is_installed": "OUI"});
+        assert!(parse_realtime_status(&record).is_err());
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -35,6 +35,60 @@ fn ensure_in_service_area(coords: &Coordinates) -> Result<()> {
     Ok(())
 }
 
+/// Aggregate a set of stations into area statistics.
+///
+/// Pure function over an iterator so it can be unit-tested without any
+/// data-client wiring. Stations without real-time data contribute to
+/// `total_stations`, `operational_stations` (per `is_operational`), and
+/// `total_capacity`, but their bike/dock counts are treated as 0 -- the data is
+/// genuinely absent, and invented zeros for `has_bikes`/`has_docks` would be
+/// misleading. The `occupancy_rate` is bikes-over-capacity and returns 0.0
+/// when no capacity is present.
+fn aggregate_area_statistics<'a, I>(stations: I) -> AreaStatistics
+where
+    I: IntoIterator<Item = &'a VelibStation>,
+{
+    let mut total_stations = 0u32;
+    let mut operational_stations = 0u32;
+    let mut total_capacity = 0u32;
+    let mut total_mechanical = 0u32;
+    let mut total_electric = 0u32;
+    let mut total_available_docks = 0u32;
+
+    for station in stations {
+        total_stations += 1;
+        if station.is_operational() {
+            operational_stations += 1;
+        }
+        total_capacity += u32::from(station.reference.capacity);
+        if let Some(rt) = &station.real_time {
+            total_mechanical += u32::from(rt.bikes.mechanical);
+            total_electric += u32::from(rt.bikes.electric);
+            total_available_docks += u32::from(rt.available_docks);
+        }
+    }
+
+    let total_bikes = total_mechanical + total_electric;
+    let occupancy_rate = if total_capacity > 0 {
+        f64::from(total_bikes) / f64::from(total_capacity)
+    } else {
+        0.0
+    };
+
+    AreaStatistics {
+        total_stations,
+        operational_stations,
+        total_capacity,
+        available_bikes: AvailableBikesStats {
+            mechanical: total_mechanical,
+            electric: total_electric,
+            total: total_bikes,
+        },
+        available_docks: total_available_docks,
+        occupancy_rate,
+    }
+}
+
 /// Find stations near a point, filtering by distance and a custom predicate,
 /// sorted by distance and truncated to `limit` results.
 ///
@@ -233,60 +287,15 @@ impl McpToolHandler {
         &self,
         input: GetAreaStatisticsInput,
     ) -> Result<GetAreaStatisticsOutput> {
-        // Fetch live station data
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        // Filter stations within the specified bounds
-        let area_stations: Vec<&VelibStation> = all_stations
+        let area_stations = all_stations
             .iter()
-            .filter(|station| input.bounds.contains(&station.reference.coordinates))
-            .collect();
-
-        // Calculate area statistics from live data
-        let total_stations = area_stations.len() as u32;
-        let operational_stations = area_stations
-            .iter()
-            .filter(|station| station.is_operational())
-            .count() as u32;
-
-        let mut total_capacity = 0u32;
-        let mut total_mechanical = 0u32;
-        let mut total_electric = 0u32;
-        let mut total_available_docks = 0u32;
-
-        for station in &area_stations {
-            total_capacity += u32::from(station.reference.capacity);
-
-            if let Some(rt) = &station.real_time {
-                total_mechanical += u32::from(rt.bikes.mechanical);
-                total_electric += u32::from(rt.bikes.electric);
-                total_available_docks += u32::from(rt.available_docks);
-            }
-        }
-
-        let total_bikes = total_mechanical + total_electric;
-        let occupancy_rate = if total_capacity > 0 {
-            f64::from(total_bikes) / f64::from(total_capacity)
-        } else {
-            0.0
-        };
-
-        let stats = AreaStatistics {
-            total_stations,
-            operational_stations,
-            total_capacity,
-            available_bikes: AvailableBikesStats {
-                mechanical: total_mechanical,
-                electric: total_electric,
-                total: total_bikes,
-            },
-            available_docks: total_available_docks,
-            occupancy_rate,
-        };
+            .filter(|station| input.bounds.contains(&station.reference.coordinates));
 
         Ok(GetAreaStatisticsOutput {
-            area_stats: stats,
+            area_stats: aggregate_area_statistics(area_stations),
             bounds: input.bounds,
         })
     }
@@ -391,14 +400,6 @@ impl McpToolHandler {
     ) -> Result<Vec<crate::types::VelibStation>> {
         let mut data_client = self.data_client.write().await;
         data_client.get_all_stations(include_realtime).await
-    }
-
-    /// Test connectivity to data sources for health checks
-    pub async fn test_connectivity(&self) -> Result<()> {
-        let mut data_client = self.data_client.write().await;
-        // Simple connectivity test by fetching reference data
-        data_client.get_all_stations(false).await?;
-        Ok(())
     }
 }
 
@@ -633,5 +634,74 @@ mod tests {
             Err(Error::InvalidCoordinates { .. }) => {}
             other => panic!("expected InvalidCoordinates, got {other:?}"),
         }
+    }
+
+    // --- aggregate_area_statistics ---
+
+    #[test]
+    fn aggregate_empty_iterator_yields_zeroed_stats() {
+        let stats = aggregate_area_statistics(std::iter::empty());
+        assert_eq!(stats.total_stations, 0);
+        assert_eq!(stats.operational_stations, 0);
+        assert_eq!(stats.total_capacity, 0);
+        assert_eq!(stats.available_bikes.total, 0);
+        assert_eq!(stats.available_docks, 0);
+        assert_eq!(stats.occupancy_rate, 0.0);
+    }
+
+    #[test]
+    fn aggregate_sums_bikes_and_docks_across_stations() {
+        let a = make_station("a", 48.85, 2.35, 4, 2); // 6 bikes, 14 docks
+        let b = make_station("b", 48.86, 2.36, 1, 3); // 4 bikes, 16 docks
+        let stations = vec![a, b];
+
+        let stats = aggregate_area_statistics(&stations);
+
+        assert_eq!(stats.total_stations, 2);
+        assert_eq!(stats.operational_stations, 2);
+        assert_eq!(stats.total_capacity, 40); // 20 + 20
+        assert_eq!(stats.available_bikes.mechanical, 5);
+        assert_eq!(stats.available_bikes.electric, 5);
+        assert_eq!(stats.available_bikes.total, 10);
+        assert_eq!(stats.available_docks, 30);
+        // 10 bikes / 40 capacity = 0.25
+        assert!((stats.occupancy_rate - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_counts_stations_without_realtime_as_operational() {
+        // Matches `VelibStation::is_operational`: missing real-time data
+        // defaults to operational.
+        let mut s = make_station("x", 48.85, 2.35, 0, 0);
+        s.real_time = None;
+
+        let stats = aggregate_area_statistics(std::iter::once(&s));
+
+        assert_eq!(stats.total_stations, 1);
+        assert_eq!(stats.operational_stations, 1);
+        assert_eq!(stats.total_capacity, 20);
+        assert_eq!(stats.available_bikes.total, 0);
+        assert_eq!(stats.available_docks, 0);
+        // bikes=0, capacity>0 -> occupancy 0.0
+        assert_eq!(stats.occupancy_rate, 0.0);
+    }
+
+    #[test]
+    fn aggregate_excludes_closed_stations_from_operational_count() {
+        let mut closed = make_station("closed", 48.85, 2.35, 5, 0);
+        if let Some(rt) = closed.real_time.as_mut() {
+            rt.status = StationStatus::Closed;
+        }
+        let open = make_station("open", 48.86, 2.36, 2, 0);
+        let stations = vec![closed, open];
+
+        let stats = aggregate_area_statistics(&stations);
+
+        assert_eq!(stats.total_stations, 2);
+        // Only the `Open` station counts as operational; the `Closed` one still
+        // contributes capacity and its bike count (accurate reporting, not
+        // availability for rental).
+        assert_eq!(stats.operational_stations, 1);
+        assert_eq!(stats.available_bikes.total, 7);
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8,7 +8,7 @@ use axum::{
 use chrono::Utc;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -20,15 +20,11 @@ use crate::{Error, Result};
 
 pub struct McpServer {
     tool_handler: Arc<McpToolHandler>,
-    clients: Arc<RwLock<HashMap<String, WebSocketClient>>>,
+    /// Live WebSocket client ids. Tracking them as a set (rather than a
+    /// `HashMap<String, Metadata>` with an unused metadata struct) keeps the
+    /// connection bookkeeping minimal while still allowing future extension.
+    clients: Arc<RwLock<HashSet<String>>>,
     start_time: Instant,
-}
-
-#[derive(Debug)]
-struct WebSocketClient {
-    #[allow(dead_code)]
-    id: String,
-    // Additional client metadata can be added here
 }
 
 impl Default for McpServer {
@@ -42,7 +38,7 @@ impl McpServer {
     pub fn new() -> Self {
         Self {
             tool_handler: Arc::new(McpToolHandler::new()),
-            clients: Arc::new(RwLock::new(HashMap::new())),
+            clients: Arc::new(RwLock::new(HashSet::new())),
             start_time: Instant::now(),
         }
     }
@@ -115,20 +111,14 @@ impl McpServer {
     async fn handle_websocket_connection(
         mut socket: WebSocket,
         handler: Arc<McpToolHandler>,
-        clients: Arc<RwLock<HashMap<String, WebSocketClient>>>,
+        clients: Arc<RwLock<HashSet<String>>>,
     ) {
         let client_id = uuid::Uuid::new_v4().to_string();
         info!("New WebSocket connection: {}", client_id);
 
-        // Add client to the map
         {
             let mut clients_guard = clients.write().await;
-            clients_guard.insert(
-                client_id.clone(),
-                WebSocketClient {
-                    id: client_id.clone(),
-                },
-            );
+            clients_guard.insert(client_id.clone());
         }
 
         // Handle messages
@@ -258,7 +248,7 @@ impl McpServer {
                             "type": "object",
                             "properties": {
                                 "query": {"type": "string", "minLength": 2},
-                                "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+                                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 10},
                                 "fuzzy": {"type": "boolean", "default": true}
                             },
                             "required": ["query"]
@@ -534,22 +524,18 @@ async fn get_complete_stations_resource(handler: Arc<McpToolHandler>) -> Result<
     }))
 }
 
-/// Get health resource data with real metrics
+/// Get health resource data with real metrics.
+///
+/// Reports real uptime, real cache sizes, and real data lag computed from the
+/// most recent `last_update` across all stations. A synthetic `hit_rate` is
+/// intentionally omitted: the cache does not track hits/misses, so fabricating
+/// a number would be misleading.
 async fn get_health_resource(handler: Arc<McpToolHandler>, start_time: Instant) -> Result<Value> {
     let uptime_seconds = start_time.elapsed().as_secs();
 
-    // Get real cache statistics
     let (reference_cache_size, realtime_cache_size) = handler.cache_stats().await;
     let total_entries = reference_cache_size + realtime_cache_size;
 
-    // Calculate hit rate based on cache usage (simplified)
-    let hit_rate = if total_entries > 0 {
-        0.75 + (total_entries as f64 / 2000.0) * 0.2
-    } else {
-        0.0
-    };
-
-    // Fetch stations to compute real lag from most recent station last_update timestamp
     let (realtime_status, reference_status, lag_seconds, most_recent_update) =
         match handler.get_complete_stations(true).await {
             Ok(stations) => {
@@ -581,7 +567,6 @@ async fn get_health_resource(handler: Arc<McpToolHandler>, start_time: Instant) 
             }
         },
         "cache_stats": {
-            "hit_rate": hit_rate.min(1.0),
             "entries": total_entries,
             "reference_cache_size": reference_cache_size,
             "realtime_cache_size": realtime_cache_size

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -191,6 +191,9 @@ pub struct JsonRpcRequest {
     pub jsonrpc: String,
     pub id: serde_json::Value,
     pub method: String,
+    /// JSON-RPC 2.0 permits omitting `params` entirely; default to null so
+    /// parameterless calls like `tools/list` need not include an empty object.
+    #[serde(default)]
     pub params: serde_json::Value,
 }
 

--- a/tests/mcp_resource_tests.rs
+++ b/tests/mcp_resource_tests.rs
@@ -147,20 +147,22 @@ async fn test_health_endpoint_returns_real_metrics() {
     // Currently fails: should have real cache statistics, not hardcoded values
     assert_eq!(json_response["status"], "healthy");
 
-    // Validate cache stats are real (not hardcoded)
+    // Validate cache stats expose real sizes, not hardcoded or fabricated metrics.
     let cache_stats = &json_response["cache_stats"];
-    assert!(cache_stats["hit_rate"].is_number());
     assert!(cache_stats["entries"].is_number());
+    assert!(cache_stats["reference_cache_size"].is_number());
+    assert!(cache_stats["realtime_cache_size"].is_number());
+    // `hit_rate` was removed because the cache does not track hits/misses.
+    assert!(
+        cache_stats["hit_rate"].is_null(),
+        "hit_rate must not be synthesized"
+    );
 
     // Validate data source statuses are real
     let data_sources = &json_response["data_sources"];
     assert!(data_sources["real_time"]["status"].is_string());
     assert!(data_sources["real_time"]["last_update"].is_string());
     assert!(data_sources["reference"]["status"].is_string());
-
-    // The hit_rate should not be exactly 0.85 (hardcoded value) when testing with real data
-    let hit_rate = cache_stats["hit_rate"].as_f64().unwrap();
-    assert_ne!(hit_rate, 0.85, "Hit rate should not be hardcoded 0.85");
 }
 
 /// Test error handling when data source is unavailable

--- a/tests/mcp_server_routing_tests.rs
+++ b/tests/mcp_server_routing_tests.rs
@@ -92,6 +92,27 @@ async fn tools_list_returns_all_five_tools() {
 }
 
 #[tokio::test]
+async fn search_stations_by_name_schema_limit_matches_handler_enforcement() {
+    // The advertised schema max must match the handler's `MAX_RESULT_LIMIT`
+    // (100). A drift here silently shrinks the tool's advertised capability
+    // and can be caught early by this regression test.
+    let (_, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    }))
+    .await;
+
+    let tools = body["result"]["tools"].as_array().unwrap();
+    let search = tools
+        .iter()
+        .find(|t| t["name"] == "search_stations_by_name")
+        .expect("schema includes search_stations_by_name");
+    assert_eq!(search["inputSchema"]["properties"]["limit"]["maximum"], 100);
+}
+
+#[tokio::test]
 async fn tools_list_entries_have_required_schema_fields() {
     let (_, body) = post_mcp(json!({
         "jsonrpc": "2.0",
@@ -378,6 +399,23 @@ async fn request_with_string_id_preserves_id_in_response() {
     .await;
 
     assert_eq!(body["id"], "client-generated-id");
+}
+
+#[tokio::test]
+async fn tools_list_accepts_request_with_omitted_params() {
+    // JSON-RPC 2.0 allows `params` to be omitted; the server must not reject
+    // parameterless calls like `tools/list`. Regression guard for the
+    // `#[serde(default)]` on `JsonRpcRequest::params`.
+    let (status, body) = post_mcp(json!({
+        "jsonrpc": "2.0",
+        "id": 99,
+        "method": "tools/list"
+    }))
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["id"], 99);
+    assert!(body["result"]["tools"].is_array());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Architecture
- **JSON-RPC 2.0 compliance**: `JsonRpcRequest.params` now defaults to `null`, so parameterless calls like `tools/list` need not include an empty object. [`src/mcp/types.rs`](../blob/claude/youthful-brahmagupta-eZig4/src/mcp/types.rs)
- **Honest health metrics**: removed the fabricated `hit_rate` from `velib://health`; the cache tracks no hits/misses, so the formula was cosmetic. Real cache sizes and data lag are retained. [`src/mcp/server.rs`](../blob/claude/youthful-brahmagupta-eZig4/src/mcp/server.rs)
- **Schema/handler drift fix**: `search_stations_by_name`'s advertised `limit` max was 50 while the handler enforced 100. Aligned the schema to reflect reality.
- **Dead-code cleanup**: replaced `HashMap<String, WebSocketClient>` (whose sole field was `#[allow(dead_code)]`) with a plain `HashSet<String>`; deleted the unused `McpToolHandler::test_connectivity` helper.
- **Refactor for testability**: extracted `aggregate_area_statistics` as a pure iterator-driven function, and moved `parse_reference_station` / `parse_realtime_status` to free functions (they never used `&self`).

## Testing
- New unit coverage for the Paris Open Data parsers against fixture JSON — happy path, missing required fields, and each `StationStatus` mapping (`OPEN`, `MAINTENANCE`, `CLOSED`). [`src/data/client.rs`](../blob/claude/youthful-brahmagupta-eZig4/src/data/client.rs)
- New unit coverage for `aggregate_area_statistics` — empty input, sum across stations, missing real-time data, closed station excluded from operational count. [`src/mcp/handlers.rs`](../blob/claude/youthful-brahmagupta-eZig4/src/mcp/handlers.rs)
- Routing regression guards: `tools/list` accepted with omitted `params`; advertised `search_stations_by_name` schema max matches handler's enforcement. [`tests/mcp_server_routing_tests.rs`](../blob/claude/youthful-brahmagupta-eZig4/tests/mcp_server_routing_tests.rs)
- Updated the ignored `velib://health` resource test to assert `hit_rate` is absent.

Library test count: 67 → 78; integration routing tests: 16 → 18.

## Clarity
- `docs/context/etat_actuel.md` declared Phase 2 as "Prêt à commencer" despite Phases 0-4 shipping long ago. Replaced with a concise status table linking into the delivered code.
- `docs/development/project_prompt.md` was an 18-line corrupted stub ending in `[... rest of the original prompt content ...]` that duplicated CLAUDE.md. Collapsed to a pointer to the authoritative CLAUDE.md.

## Test plan
- [x] `cargo test` — all suites green (78 lib + 18 routing + 11 types + 8 validation + 4 data_client + 2 smoke + 1 cache + doctests).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] CI: Test Suite, Rustfmt, Clippy, Security Audit, Feature Testing, Coverage, Build, all-checks gate.

https://claude.ai/code/session_01XkE52kb74MuBFgU4VrSTX6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkE52kb74MuBFgU4VrSTX6)_