### PR TITLE
docs: tighten README, CLAUDE.md, and source comments for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,10 @@ Tu es un développeur Rust expert travaillant sur un projet open-source de serve
 **Important** : Ce fichier CLAUDE.md est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
 
 ## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
+Créer un serveur cloud MCP performant exposant aux assistants IA les deux jeux de données parisiens suivants, pour la planification des transports et l'analyse des flux de trajets :
 
 - **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
 - **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
-
-- **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
 
 ## État Actuel du Projet
 
@@ -57,12 +55,12 @@ Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA
 - **Validations sécurité** incluant limites zone service 50km
 
 ### Fichiers Importants
-- `/src/main.rs` - Point d'entrée principal
-- `/src/mcp/` - Implémentation protocole MCP
-- `/src/data/` - Client données et cache
-- `/src/types.rs` - Structures de données principales
-- `/docs/api/data_analysis.md` - Analyse données complète
-- `/docs/context/etat_actuel.md` - Suivi statut projet
+- `src/main.rs` - Point d'entrée principal
+- `src/mcp/` - Implémentation protocole MCP
+- `src/data/` - Client données et cache
+- `src/types.rs` - Structures de données principales
+- `docs/api/data_analysis.md` - Analyse données complète
+- `docs/context/etat_actuel.md` - Suivi statut projet
 
 ### Commandes Développement
 ```bash
@@ -210,9 +208,8 @@ done
 - [ ] Documentation à jour
 ```
 
-### Métriques de Performance
+### Métriques de Performance (objectifs indicatifs vs processus linéaire)
 
-**Gains Attendus vs Processus Linéaire**
 - **Temps cycle**: -40% (parallélisation phases)
 - **Temps attente**: -60% (élimination handoffs)
 - **Qualité code**: +25% (validation continue)
@@ -220,8 +217,8 @@ done
 
 ### Intégration Architecture Existante
 
-Ce processus s'intègre parfaitement avec:
-- Architecture worktree existante (isolation parallèle)
+Ce processus s'appuie sur :
+- Architecture worktree (isolation parallèle)
 - CI/CD GitHub Actions (validation automatisée)
 - Hooks pre-commit (qualité continue)
 - Toolchain Rust standard (fmt, clippy, audit)

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ A high-performance Model Context Protocol (MCP) server providing access to Paris
 
 ## Quick Start - Install with Claude Code
 
-Install and use the Velib MCP server with Claude Code in one command:
+Install the server, then register it with Claude Code:
 
 ```bash
-# Install and configure the server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-claude config add-server velib-mcp "cargo run --release -- --port 3000"
+claude mcp add velib-mcp velib-mcp
 ```
 
-Then use in Claude Code:
+Example prompts in Claude Code:
 ```
 @velib find nearby stations at latitude 48.8566 longitude 2.3522
 @velib get station by code 16107
@@ -50,20 +49,17 @@ This project exposes two key Parisian datasets through MCP:
 <details>
 <summary>Click to expand integration guides</summary>
 
-### ChatGPT
+Install once (all clients):
 ```bash
-# Install server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server on port 8080
-velib-mcp
-# Configure in ChatGPT Custom Instructions or use via API
 ```
 
+### ChatGPT
+Run `velib-mcp` and wire it through ChatGPT Custom Instructions or the API.
+
 ### Cursor
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Add to Cursor's settings.json
+Add to Cursor's `settings.json`:
+```json
 {
   "mcp.servers": {
     "velib": {
@@ -75,19 +71,10 @@ cargo install --git https://github.com/dominicburkart/velib-mcp.git
 ```
 
 ### Le Chat / Mistral
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server and use via API calls
-velib-mcp --port 8080
-```
+Run `velib-mcp --port 8080` and call it via the API.
 
 ### Windsurf
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Configure in Windsurf MCP settings
-```
+Configure `velib-mcp` in Windsurf's MCP settings.
 
 </details>
 
@@ -119,16 +106,15 @@ cargo deny check licenses bans sources
 
 ### Pre-commit hooks
 
-`cargo-husky` is installed as a dev-dependency and automatically installs a Git
-pre-commit hook the first time `cargo test` (or any cargo command that builds
-dev-dependencies) runs. The hook lives at `.cargo-husky/hooks/pre-commit` and
-enforces:
+`cargo-husky` (dev-dependency) installs a Git pre-commit hook the first time
+any cargo command builds dev-dependencies (e.g. `cargo test`). The hook at
+`.cargo-husky/hooks/pre-commit` runs:
 
 - `cargo clippy --fix --all-features --all-targets`
 - `cargo fmt --all`
 - `cargo sort`
-- `cargo deny check licenses bans sources` (mirrors the `license-compliance` CI
-  job so license, bans, and source-provenance regressions are caught locally)
+- `cargo deny check licenses bans sources` (mirrors the `license-compliance`
+  CI job so regressions are caught locally)
 
 Any non-zero exit aborts the commit.
 
@@ -149,7 +135,7 @@ The project is configured for deployment to Scaleway Container Serverless via Gi
 ## Architecture
 
 - **Language**: Rust
-- **Deployment**: Scaleway Container Serverless  
+- **Deployment**: Scaleway Container Serverless
 - **CI/CD**: GitHub Actions
 - **Development**: Test-Driven Development approach
 - **Container**: Distroless Debian base image

--- a/docs/context/etat_actuel.md
+++ b/docs/context/etat_actuel.md
@@ -1,9 +1,9 @@
 # État Actuel du Projet Velib MCP
 
-## Phase Actuelle: Phase 2 - Architecture Système
+## Phase Actuelle : voir `CLAUDE.md` pour l'état par phases
 
-### Statut: Prêt à commencer
-Date de dernière mise à jour: 2025-06-14
+Dernière mise à jour de ce fichier : 2025-06-14. Pour l'avancement détaillé
+à jour, se reporter à la section « État Actuel du Projet » de `CLAUDE.md`.
 
 ## Phase 0 - Configuration (TERMINÉE ✅)
 - ✅ Initialisation du projet Rust avec cargo

--- a/docs/development/project_prompt.md
+++ b/docs/development/project_prompt.md
@@ -16,4 +16,5 @@ Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA
 
 **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
 
-[... rest of the original prompt content ...]
+Pour le contexte opérationnel complet (structure projet, phases, processus
+multi-agents), voir `CLAUDE.md` à la racine du dépôt.

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -253,11 +253,11 @@ impl VelibDataClient {
 
         let coordinates = crate::types::Coordinates::new(latitude, longitude);
 
-        // Parse service capabilities
+        // Service capabilities are not exposed by the current API.
         let capabilities = ServiceCapabilities {
-            accepts_credit_card: false,  // Not available in current API
-            has_charging_station: false, // Not available in current API
-            is_virtual_station: false,   // Not available in current API
+            accepts_credit_card: false,
+            has_charging_station: false,
+            is_virtual_station: false,
         };
 
         Ok(StationReference {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -17,9 +17,9 @@ use tokio::sync::RwLock;
 const MAX_SEARCH_RADIUS: u32 = 5000; // 5km
 const MAX_RESULT_LIMIT: u16 = 100;
 
-/// Validate that a coordinate is within the Velib service area, returning the
-/// appropriate `Error` if not. Centralizes the two checks previously duplicated
-/// across each handler (valid Paris metro bounds + 50km-of-City-Hall).
+/// Validate that a coordinate is within the Velib service area (valid Paris
+/// metro bounds and within 50km of City Hall), returning the appropriate
+/// `Error` if not.
 fn ensure_in_service_area(coords: &Coordinates) -> Result<()> {
     if !coords.is_valid_paris_metro() {
         return Err(Error::InvalidCoordinates {
@@ -38,12 +38,11 @@ fn ensure_in_service_area(coords: &Coordinates) -> Result<()> {
 /// Find stations near a point, filtering by distance and a custom predicate,
 /// sorted by distance and truncated to `limit` results.
 ///
-/// Each matched station is cloned into the returned `StationWithDistance`. This
-/// is intentional: callers that hold the original slice (e.g. `plan_bike_journey`,
-/// which needs `all_stations` for both the pickup and the dropoff pass) must not
-/// have their data consumed. For `find_nearby_stations`, which previously used
-/// `into_iter()`, this introduces one extra clone per matched station; given the
-/// Paris Velib network of ~1,400 stations this overhead is negligible.
+/// Each matched station is cloned into the returned `StationWithDistance` so
+/// that callers retaining the original slice (e.g. `plan_bike_journey`, which
+/// reuses `all_stations` for both pickup and dropoff passes) are not
+/// consumed. The extra clone per match is negligible at the ~1,400-station
+/// scale of the Paris Velib network.
 fn find_stations_within_radius(
     stations: &[VelibStation],
     origin: &Coordinates,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -28,7 +28,6 @@ pub struct McpServer {
 struct WebSocketClient {
     #[allow(dead_code)]
     id: String,
-    // Additional client metadata can be added here
 }
 
 impl Default for McpServer {


### PR DESCRIPTION
## Summary

Clarity pass over docs and code comments, preserving information content.

- **README.md**: Replace stale `claude config add-server` with the current `claude mcp add` flow; deduplicate the per-client `cargo install` line across the integration guides; compact the pre-commit hooks description; strip a trailing whitespace line in Architecture.
- **CLAUDE.md**: Drop leading `/` from repo-relative file paths (so they work as `path:line` references); fold the redundant project-goal bullet into the preceding sentence; label the performance metrics as indicative targets rather than asserted outcomes.
- **docs/context/etat_actuel.md**: The "Phase Actuelle: Phase 2 - Prêt à commencer" heading was stale (CLAUDE.md documents Phases 0-4 as terminées). Point readers to CLAUDE.md for current phase status instead of asserting an out-of-date state.
- **docs/development/project_prompt.md**: Replace the literal `[... rest of the original prompt content ...]` placeholder with a pointer to CLAUDE.md.
- **src/data/client.rs**: Collapse three identical "Not available in current API" per-field comments into one header comment.
- **src/mcp/handlers.rs**: Tighten the `ensure_in_service_area` and `find_stations_within_radius` doc comments (same info, fewer words; kept the rationale for the clone).
- **src/mcp/server.rs**: Remove a dead "Additional client metadata can be added here" placeholder.

## Test plan

- [ ] CI passes (`cargo fmt`, `cargo clippy`, `cargo test`, `cargo deny`)
- [ ] `cargo check` locally confirmed a clean build before push
- [ ] Rendered README in GitHub UI previews correctly

https://claude.ai/code/session_01LEodkCtiog4uAeXmJwHnWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEodkCtiog4uAeXmJwHnWB)_