### PR TITLE
[clarity] refresh stale .claude/etat_partage.json shared state

### DIFF
--- a/.claude/etat_partage.json
+++ b/.claude/etat_partage.json
@@ -1,21 +1,31 @@
 {
   "project_name": "velib-mcp",
-  "current_phase": "Phase 2 - Architecture",
-  "last_updated": "2025-06-14",
+  "current_phase": "Maintenance",
+  "last_updated": "2026-04-26",
   "repository": "https://github.com/dominicburkart/velib-mcp",
   "main_branch": "main",
   "active_worktrees": [],
-  "completed_phases": ["Phase 0 - Configuration", "Phase 1 - Data Analysis"],
+  "completed_phases": [
+    "Phase 0 - Configuration",
+    "Phase 1 - Data Analysis",
+    "Phase 2A - Server Foundation",
+    "Phase 2B - MCP Protocol Types",
+    "Phase 3A - Live API Client",
+    "Phase 3B - MCP Handlers",
+    "Phase 4 - Repo Cleanup"
+  ],
   "current_tasks": {
     "in_progress": [
-      "System architecture design",
-      "Modular code organization planning"
+      "Iterative quality, coverage, and clarity improvements via individual PRs"
     ],
     "completed": [
       "Complete data analysis of both Velib datasets",
       "Rust data schemas and MCP interface specifications",
       "Technical documentation with 5 MCP tools defined",
-      "Project setup with CI/CD pipeline"
+      "Project setup with CI/CD pipeline",
+      "Live data client and TTL cache",
+      "MCP handlers wired to live data",
+      "Scaleway Container Serverless deployment via GitHub Actions"
     ]
   },
   "critical_decisions": [],
@@ -29,5 +39,6 @@
   "data_sources": [
     "https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/",
     "https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/"
-  ]
+  ],
+  "canonical_status_doc": "docs/context/etat_actuel.md"
 }


### PR DESCRIPTION
## Summary

`.claude/etat_partage.json` had drifted ~10 months out of sync with `docs/context/etat_actuel.md` (2026-04-23), causing the two project-status surfaces to disagree on which phases are complete.

Changes:
- `last_updated`: `2025-06-14` -> `2026-04-26` (ISO-8601 retained).
- `current_phase`: `Phase 2 - Architecture` -> `Maintenance` (matches `docs/context/etat_actuel.md`).
- `completed_phases`: extended from `[0, 1]` to `[0, 1, 2A, 2B, 3A, 3B, 4]` to match the canonical status table.
- `current_tasks.in_progress`: replaced two stale architecture tasks with the single iterative-PR line from `etat_actuel.md`.
- `current_tasks.completed`: appended live data client, MCP handler wiring, and Scaleway deploy to reflect delivered work.
- Added `canonical_status_doc: docs/context/etat_actuel.md` pointer so future readers know which file leads.

No content invented; all values mirror existing canonical doc.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_