### PR TITLE
[clarity] retitle data_analysis.md, add cross-doc relative links

### DIFF
--- a/docs/api/data_analysis.md
+++ b/docs/api/data_analysis.md
@@ -1,4 +1,4 @@
-# Analyse des Données Velib - Phase 1
+# Analyse des Données Velib
 
 ## Vue d'ensemble
 
@@ -6,6 +6,11 @@ Ce document analyse les deux jeux de données Velib disponibles via l'API Open D
 
 1. **Disponibilité temps réel** : État actuel des stations (vélos/emplacements disponibles)
 2. **Emplacements des stations** : Données de référence statiques des stations
+
+Documents liés :
+- [`mcp_schemas.md`](mcp_schemas.md) — schémas formels exposés via MCP.
+- [`mcp_interface_spec.md`](mcp_interface_spec.md) — endpoints MCP et exemples.
+- [`../../src/types.rs`](../../src/types.rs) — types Rust correspondants.
 
 ## Dataset 1 : Disponibilité Temps Réel
 


### PR DESCRIPTION
## Summary

`docs/api/data_analysis.md` is the canonical reference for the upstream Velib datasets but its title still tags it "Phase 1", which has not been the active phase since `docs/context/etat_actuel.md` was first written. The title was the only phase reference inside the file.

Changes:
- Title: `Analyse des Donnees Velib - Phase 1` -> `Analyse des Donnees Velib`.
- Added a "Documents lies" block under the overview pointing to `mcp_schemas.md`, `mcp_interface_spec.md`, and `../../src/types.rs` using relative links so readers can jump from raw-field notes to the runtime types.

No tables, examples, or constraints touched; this is a heading rename plus three relative cross-doc links.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_