### PR TITLE
[arch] remove unused DataSource enum

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -295,16 +295,6 @@ impl VelibStation {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum DataSource {
-    #[serde(rename = "paris_open_data")]
-    ParisOpenData,
-    #[serde(rename = "cache")]
-    Cache,
-    #[serde(rename = "fallback")]
-    Fallback,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Precept violation

`CLAUDE.md` and the architecture review checklist call for "patterns Rust idiomatiques respectes" and clear separation of responsibilities. `src/types.rs` defines a public `DataSource` enum (variants `ParisOpenData`, `Cache`, `Fallback`) that, after auditing the entire codebase, is **never constructed, returned, matched on, or referenced** in `src/` or `tests/`:

```
$ grep -rn DataSource src/ tests/
src/types.rs:299:pub enum DataSource {
```

It is re-exported via `pub use types::*` in `lib.rs`, so it is part of the crate's public API surface even though no caller can produce or consume a useful value of it. That is dead code that:

- inflates the public API for downstream users (cargo install + `velib_mcp::DataSource`),
- imposes a maintenance/serde-stability cost,
- contradicts the "lean, idiomatic Rust" precept in CLAUDE.md.

## Fix

Delete the enum (10 LOC). No imports, no test fixtures, no documentation references, and no MCP schemas mention it, so the removal is purely subtractive.

## Test plan

- [x] `cargo build --offline` succeeds
- [x] `cargo test --offline --lib` passes (78/78)
- [x] `cargo clippy --all-targets --offline` is clean
- [ ] CI green on draft PR

If a future change actually needs to surface data provenance, it can be reintroduced as part of that change with real call sites and tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_