### PR TITLE
refactor(velib-mcp): use crate error type in parse_server_address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use velib_mcp::{parse_server_address, Server};
+use velib_mcp::{parse_server_address, Error, Server};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Error> {
     // Initialize tracing with a sensible default if RUST_LOG is not set
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -1,7 +1,9 @@
 use std::net::SocketAddr;
 
+use crate::Result;
+
 /// Parse server configuration from environment variables
-pub fn parse_server_address() -> Result<SocketAddr, String> {
+pub fn parse_server_address() -> Result<SocketAddr> {
     let port = std::env::var("PORT")
         .ok()
         .and_then(|p| p.parse().ok())
@@ -11,7 +13,7 @@ pub fn parse_server_address() -> Result<SocketAddr, String> {
 
     format!("{ip}:{port}")
         .parse()
-        .map_err(|e| format!("Invalid IP or PORT environment variables: {e}"))
+        .map_err(|e| anyhow::anyhow!("Invalid IP or PORT environment variables: {e}").into())
 }
 
 #[cfg(test)]
@@ -79,7 +81,7 @@ mod tests {
 
         let result = parse_server_address();
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid IP or PORT"));
+        assert!(result.unwrap_err().to_string().contains("Invalid IP or PORT"));
 
         env::remove_var("IP");
     }
@@ -105,7 +107,7 @@ mod tests {
 
         let result = parse_server_address();
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid IP or PORT"));
+        assert!(result.unwrap_err().to_string().contains("Invalid IP or PORT"));
 
         env::remove_var("PORT");
     }


### PR DESCRIPTION
## Summary

- `parse_server_address` previously returned `Result<SocketAddr, String>`, making it the only function in the project not using `crate::Error`.
- Changed return type to `crate::Result<SocketAddr>` (i.e. `Result<SocketAddr, crate::Error>`).
- The error is now constructed with `anyhow::anyhow!(...)` and converted to `Error::Internal` via the existing `#[from] anyhow::Error` impl — no new variants or dependencies needed.
- `main.rs` return type tightened from `Result<(), Box<dyn std::error::Error>>` to `Result<(), velib_mcp::Error>`, eliminating the type erasure that was forced by the bare `String` error.
- Test assertions on the error case updated from `.contains(...)` on a `String` to `.to_string().contains(...)` on a `crate::Error`, preserving identical behaviour.

## Test plan

- [ ] `cargo test` passes (all existing tests in `config.rs` still exercise the same code paths)
- [ ] `cargo build` succeeds with no type errors
- [ ] Confirm error message `"Invalid IP or PORT environment variables: ..."` is still surfaced correctly at runtime when `IP`/`PORT` env vars are invalid


---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_