### PR TITLE
fix(velib-mcp): compute DataFreshness dynamically in resource handlers

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -16,6 +16,7 @@ use tracing::{error, info, warn};
 
 use super::handlers::McpToolHandler;
 use super::types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
+use crate::types::DataFreshness;
 use crate::{Error, Result};
 
 pub struct McpServer {
@@ -476,7 +477,7 @@ async fn get_reference_stations_resource(handler: Arc<McpToolHandler>) -> Result
     }))
 }
 
-/// Get real-time stations resource data  
+/// Get real-time stations resource data
 async fn get_realtime_stations_resource(handler: Arc<McpToolHandler>) -> Result<Value> {
     let realtime_status = handler.get_realtime_status().await?;
 
@@ -498,11 +499,22 @@ async fn get_realtime_stations_resource(handler: Arc<McpToolHandler>) -> Result<
         })
         .collect();
 
+    // Derive overall freshness from the most-recent last_update across all entries.
+    let data_freshness = realtime_status
+        .values()
+        .map(|s| s.last_update)
+        .max()
+        .map(|most_recent| {
+            let age_minutes = (Utc::now() - most_recent).num_seconds() as f64 / 60.0;
+            DataFreshness::from_age(age_minutes)
+        })
+        .unwrap_or(DataFreshness::VeryStale);
+
     Ok(json!({
         "stations": stations,
         "metadata": {
             "total_stations": stations.len(),
-            "data_freshness": "Fresh",
+            "data_freshness": data_freshness,
             "response_time": chrono::Utc::now(),
             "data_source": "live"
         }
@@ -513,11 +525,22 @@ async fn get_realtime_stations_resource(handler: Arc<McpToolHandler>) -> Result<
 async fn get_complete_stations_resource(handler: Arc<McpToolHandler>) -> Result<Value> {
     let stations = handler.get_complete_stations(true).await?;
 
+    // Derive overall freshness from the most-recent last_update across all stations.
+    let data_freshness = stations
+        .iter()
+        .filter_map(|s| s.real_time.as_ref().map(|rt| rt.last_update))
+        .max()
+        .map(|most_recent| {
+            let age_minutes = (Utc::now() - most_recent).num_seconds() as f64 / 60.0;
+            DataFreshness::from_age(age_minutes)
+        })
+        .unwrap_or(DataFreshness::VeryStale);
+
     Ok(json!({
         "stations": stations,
         "metadata": {
             "total_stations": stations.len(),
-            "data_freshness": "Fresh",
+            "data_freshness": data_freshness,
             "response_time": chrono::Utc::now(),
             "data_source": "live"
         }


### PR DESCRIPTION
## Summary

- `get_realtime_stations_resource` and `get_complete_stations_resource` previously hard-coded `"data_freshness": "Fresh"` in their response metadata regardless of the actual age of the data.
- Both handlers now find `max(last_update)` across all returned entries and call `DataFreshness::from_age(age_minutes)` on it, exactly as `get_health_resource` already does.
- When no real-time data is present the freshness falls back to `VeryStale` (the safest conservative default).

## Changes

**`src/mcp/server.rs`**
- Added `use crate::types::DataFreshness;` import.
- `get_realtime_stations_resource`: iterates `realtime_status.values()`, finds the maximum `last_update`, computes age in minutes, and calls `DataFreshness::from_age`.
- `get_complete_stations_resource`: iterates stations, filters to those with `real_time`, finds the maximum `last_update`, and calls `DataFreshness::from_age`.
- Both replace the literal `"Fresh"` string with the computed `DataFreshness` value.

## Test plan

- [ ] `cargo build` passes without errors or new warnings.
- [ ] `cargo test` continues to pass (no logic changes to existing tests).
- [ ] Manual: call `GET /resources/velib://stations/realtime` and `GET /resources/velib://stations/complete`; verify `metadata.data_freshness` reflects the actual age of the station data (e.g. `"Recent"` when data is 15 minutes old) rather than always returning `"Fresh"`.
- [ ] Verify `GET /resources/velib://health` is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_