### PR TITLE
fix(velib-mcp): return JSON-RPC error envelope for protocol errors instead of HTTP 500

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -305,14 +305,36 @@ impl McpServer {
                 ]
             })),
             "tools/call" => {
-                let params = request
-                    .params
-                    .as_object()
-                    .ok_or_else(|| Error::McpProtocol("Invalid params".to_string()))?;
-                let tool_name = params
-                    .get("name")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| Error::McpProtocol("Missing tool name".to_string()))?;
+                let params = match request.params.as_object() {
+                    Some(p) => p,
+                    None => {
+                        return Ok(JsonRpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32600,
+                                message: "Invalid params".to_string(),
+                                data: None,
+                            }),
+                        });
+                    }
+                };
+                let tool_name = match params.get("name").and_then(|v| v.as_str()) {
+                    Some(name) => name,
+                    None => {
+                        return Ok(JsonRpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32603,
+                                message: "Missing tool name".to_string(),
+                                data: None,
+                            }),
+                        });
+                    }
+                };
                 let empty_args = json!({});
                 let arguments = params.get("arguments").unwrap_or(&empty_args);
 

--- a/tests/mcp_server_routing_tests.rs
+++ b/tests/mcp_server_routing_tests.rs
@@ -206,10 +206,10 @@ async fn tools_call_unknown_tool_returns_jsonrpc_error() {
 }
 
 #[tokio::test]
-async fn tools_call_missing_tool_name_returns_500() {
-    // The `?` after `ok_or_else(... "Missing tool name")` early-returns from
-    // `process_jsonrpc_request`, so the outer handler maps the error to a
-    // 500 with a plain `{"error": ...}` body (no JSON-RPC envelope).
+async fn tools_call_missing_tool_name_returns_jsonrpc_error() {
+    // Per JSON-RPC 2.0, protocol errors must be returned as HTTP 200 with a
+    // JSON-RPC error body rather than an HTTP 500. The server now returns a
+    // JSON-RPC error envelope with code -32603 when the tool name is absent.
     let (status, body) = post_mcp(json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -220,8 +220,13 @@ async fn tools_call_missing_tool_name_returns_500() {
     }))
     .await;
 
-    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    assert!(body["error"]
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["jsonrpc"], "2.0");
+    assert!(body["result"].is_null());
+    let error = &body["error"];
+    assert!(error.is_object());
+    assert_eq!(error["code"], -32603);
+    assert!(error["message"]
         .as_str()
         .unwrap()
         .to_lowercase()
@@ -229,9 +234,10 @@ async fn tools_call_missing_tool_name_returns_500() {
 }
 
 #[tokio::test]
-async fn tools_call_non_object_params_returns_500() {
-    // Same early-return path as the missing-tool-name case: `params.as_object()`
-    // returns None and `?` propagates "Invalid params" out as a 500.
+async fn tools_call_non_object_params_returns_jsonrpc_error() {
+    // Per JSON-RPC 2.0, protocol errors must be returned as HTTP 200 with a
+    // JSON-RPC error body rather than an HTTP 500. The server now returns a
+    // JSON-RPC error envelope with code -32600 when params is not an object.
     let (status, body) = post_mcp(json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -240,8 +246,13 @@ async fn tools_call_non_object_params_returns_500() {
     }))
     .await;
 
-    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    assert!(body["error"]
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["jsonrpc"], "2.0");
+    assert!(body["result"].is_null());
+    let error = &body["error"];
+    assert!(error.is_object());
+    assert_eq!(error["code"], -32600);
+    assert!(error["message"]
         .as_str()
         .unwrap()
         .to_lowercase()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- In `process_jsonrpc_request`, replace the two `?` early-returns (for `params.as_object()` and the tool-name `.get()` check) with `match` arms that return `Ok(JsonRpcResponse { error: Some(...), result: None, … })` so protocol errors produce HTTP 200 with a JSON-RPC error body.
- `params` not being an object now returns error code `-32600` ("Invalid params"); missing tool name returns error code `-32603` ("Missing tool name").
- Rename `tools_call_missing_tool_name_returns_500` → `tools_call_missing_tool_name_returns_jsonrpc_error` and `tools_call_non_object_params_returns_500` → `tools_call_non_object_params_returns_jsonrpc_error`, updating their assertions to expect HTTP 200 with the correct JSON-RPC error envelope.

## Motivation

The JSON-RPC 2.0 spec requires that all protocol-level errors (malformed method parameters, missing required fields, etc.) be reported as HTTP 200 responses carrying a `{"error": {"code": ..., "message": ...}}` body. Propagating these errors as HTTP 500 breaks any compliant JSON-RPC client that inspects the error envelope rather than the HTTP status code.

## Test plan

- [ ] `cargo test tools_call_missing_tool_name_returns_jsonrpc_error` passes (HTTP 200, `error.code == -32603`)
- [ ] `cargo test tools_call_non_object_params_returns_jsonrpc_error` passes (HTTP 200, `error.code == -32600`)
- [ ] All other routing tests continue to pass (`cargo test --test mcp_server_routing_tests`)
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_