### PR TITLE
refactor(velib-mcp): extract fetch_stations helper to deduplicate handler lock-acquire pattern

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -150,6 +150,15 @@ impl McpToolHandler {
         }
     }
 
+    /// Acquire a write lock on the data client and fetch all stations with
+    /// real-time data.  Every handler that needs the full station list should
+    /// call this helper instead of repeating the lock-acquire + `get_all_stations`
+    /// sequence inline.
+    async fn fetch_stations(&self) -> Result<Vec<VelibStation>> {
+        let mut data_client = self.data_client.write().await;
+        data_client.get_all_stations(true).await
+    }
+
     pub async fn find_nearby_stations(
         &self,
         input: FindNearbyStationsInput,
@@ -175,8 +184,7 @@ impl McpToolHandler {
         ensure_in_service_area(&query_point)?;
 
         // Fetch live station data
-        let mut data_client = self.data_client.write().await;
-        let all_stations = data_client.get_all_stations(true).await?;
+        let all_stations = self.fetch_stations().await?;
 
         // Filter stations by distance and bike type
         let stations = find_stations_within_radius(
@@ -242,8 +250,7 @@ impl McpToolHandler {
         }
 
         // Fetch live station data and search by name
-        let mut data_client = self.data_client.write().await;
-        let all_stations = data_client.get_all_stations(true).await?;
+        let all_stations = self.fetch_stations().await?;
 
         let query_normalized = input.query.to_lowercase().nfc().collect::<String>();
         let mut matching_stations: Vec<VelibStation> = all_stations
@@ -287,8 +294,7 @@ impl McpToolHandler {
         &self,
         input: GetAreaStatisticsInput,
     ) -> Result<GetAreaStatisticsOutput> {
-        let mut data_client = self.data_client.write().await;
-        let all_stations = data_client.get_all_stations(true).await?;
+        let all_stations = self.fetch_stations().await?;
 
         let area_stations = all_stations
             .iter()
@@ -308,8 +314,7 @@ impl McpToolHandler {
         ensure_in_service_area(&input.destination)?;
 
         // Find nearby stations for pickup and dropoff using live data
-        let mut data_client = self.data_client.write().await;
-        let all_stations = data_client.get_all_stations(true).await?;
+        let all_stations = self.fetch_stations().await?;
 
         // Get preferences or use defaults
         let preferences = input.preferences.unwrap_or_default();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a private `async fn fetch_stations(&self) -> Result<Vec<VelibStation>>` on `McpToolHandler` that acquires the write lock on `data_client` and calls `get_all_stations(true)`.
- Replaces the four inline lock-acquire + `get_all_stations` sequences in `find_nearby_stations`, `search_stations_by_name`, `get_area_statistics`, and `plan_bike_journey` with `self.fetch_stations().await?`.
- `get_station_by_code` is intentionally left unchanged — it calls `get_station_by_code` on the data client, not `get_all_stations`, so it is a distinct pattern.
- The helper uses `&self` consistent with the current state of the codebase (the `&mut self` → `&self` fix has already landed).

## Motivation

Any future cross-cutting concern applied to this fetch path (switching the lock kind, adding tracing/metrics, changing the `include_realtime` flag) previously required touching four separate call sites. The helper reduces that to one.

## Test plan

- [ ] `cargo check` passes — no new compiler errors introduced.
- [ ] `cargo test` passes — all existing unit tests continue to pass; no logic was changed, only the lock/fetch sequence was extracted.
- [ ] `cargo clippy` passes — the new private helper is used at all four call sites, so no dead-code warnings.
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_