### PR TITLE
refactor(velib-mcp): change data client methods from &mut self to &self, use read locks

### DIFF
--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -67,7 +67,7 @@ impl VelibDataClient {
     }
 
     /// Fetch all station reference data
-    pub async fn fetch_reference_stations(&mut self) -> Result<Vec<StationReference>> {
+    pub async fn fetch_reference_stations(&self) -> Result<Vec<StationReference>> {
         const CACHE_KEY: &str = "all_reference_stations";
 
         // Check cache first
@@ -125,7 +125,7 @@ impl VelibDataClient {
     }
 
     /// Fetch real-time station status data
-    pub async fn fetch_realtime_status(&mut self) -> Result<HashMap<String, RealTimeStatus>> {
+    pub async fn fetch_realtime_status(&self) -> Result<HashMap<String, RealTimeStatus>> {
         const CACHE_KEY: &str = "all_realtime_status";
 
         // Check cache first
@@ -183,7 +183,7 @@ impl VelibDataClient {
     }
 
     /// Get all stations with optional real-time data
-    pub async fn get_all_stations(&mut self, include_realtime: bool) -> Result<Vec<VelibStation>> {
+    pub async fn get_all_stations(&self, include_realtime: bool) -> Result<Vec<VelibStation>> {
         let reference_stations = self.fetch_reference_stations().await?;
 
         if !include_realtime {
@@ -211,7 +211,7 @@ impl VelibDataClient {
 
     /// Get a specific station by code
     pub async fn get_station_by_code(
-        &mut self,
+        &self,
         station_code: &str,
         include_realtime: bool,
     ) -> Result<Option<VelibStation>> {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -175,7 +175,7 @@ impl McpToolHandler {
         ensure_in_service_area(&query_point)?;
 
         // Fetch live station data
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         // Filter stations by distance and bike type
@@ -213,7 +213,7 @@ impl McpToolHandler {
         &self,
         input: GetStationByCodeInput,
     ) -> Result<GetStationByCodeOutput> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let station = data_client
             .get_station_by_code(&input.station_code, true)
             .await?;
@@ -242,7 +242,7 @@ impl McpToolHandler {
         }
 
         // Fetch live station data and search by name
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         let query_normalized = input.query.to_lowercase().nfc().collect::<String>();
@@ -287,7 +287,7 @@ impl McpToolHandler {
         &self,
         input: GetAreaStatisticsInput,
     ) -> Result<GetAreaStatisticsOutput> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         let area_stations = all_stations
@@ -308,7 +308,7 @@ impl McpToolHandler {
         ensure_in_service_area(&input.destination)?;
 
         // Find nearby stations for pickup and dropoff using live data
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
         // Get preferences or use defaults
@@ -381,7 +381,7 @@ impl McpToolHandler {
 
     /// Get reference stations for resource endpoints
     pub async fn get_reference_stations(&self) -> Result<Vec<crate::types::StationReference>> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         data_client.fetch_reference_stations().await
     }
 
@@ -389,7 +389,7 @@ impl McpToolHandler {
     pub async fn get_realtime_status(
         &self,
     ) -> Result<std::collections::HashMap<String, crate::types::RealTimeStatus>> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         data_client.fetch_realtime_status().await
     }
 
@@ -398,7 +398,7 @@ impl McpToolHandler {
         &self,
         include_realtime: bool,
     ) -> Result<Vec<crate::types::VelibStation>> {
-        let mut data_client = self.data_client.write().await;
+        let data_client = self.data_client.read().await;
         data_client.get_all_stations(include_realtime).await
     }
 }


### PR DESCRIPTION
## Summary

- `fetch_reference_stations`, `fetch_realtime_status`, `get_all_stations`, and `get_station_by_code` in `src/data/client.rs` took `&mut self` unnecessarily — all interior mutation flows through `Arc<RwLock<...>>` fields that only require a shared reference.
- All eight `self.data_client.write().await` call sites in `src/mcp/handlers.rs` have been changed to `self.data_client.read().await`, since none of those handlers perform mutations on the client itself.

## Impact

Before this change every incoming MCP request — regardless of whether it was a read or write — serialised all other requests behind a single exclusive write lock. After this change concurrent read requests (the overwhelming majority of traffic) can proceed in parallel, held only by a shared read lock.

## Test plan

- [ ] `cargo test` passes without modification — no logic was changed, only receiver mutability and lock kind.
- [ ] Manually verify that `clippy` no longer warns about unnecessary `mut` on the local `data_client` bindings in `handlers.rs`.
- [ ] Run a load test with multiple concurrent `find_nearby_stations` / `get_station_by_code` calls and confirm they no longer queue behind each other.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_