### PR TITLE
refactor(velib-mcp): consolidate MCP limit/default constants to single source of truth

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -7,15 +7,13 @@ use crate::mcp::types::{
     GetStationByCodeInput, GetStationByCodeOutput, JourneyPreferences, JourneyRecommendation,
     PlanBikeJourneyInput, PlanBikeJourneyOutput, SearchMetadata, SearchStationsByNameInput,
     SearchStationsByNameOutput, StationWithDistance, TextSearchMetadata,
+    MAX_RESULT_LIMIT, MAX_SEARCH_RADIUS,
 };
 use crate::types::{BikeTypeFilter, Coordinates, VelibStation};
 use crate::{Error, Result};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
-
-const MAX_SEARCH_RADIUS: u32 = 5000; // 5km
-const MAX_RESULT_LIMIT: u16 = 100;
 
 /// Validate that a coordinate is within the Velib service area, returning the
 /// appropriate `Error` if not. Centralizes the two checks previously duplicated

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -15,7 +15,10 @@ use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
 use super::handlers::McpToolHandler;
-use super::types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
+use super::types::{
+    JsonRpcError, JsonRpcRequest, JsonRpcResponse, DEFAULT_LIMIT, DEFAULT_RADIUS,
+    MAX_RESULT_LIMIT, MAX_SEARCH_RADIUS,
+};
 use crate::{Error, Result};
 
 pub struct McpServer {
@@ -222,8 +225,18 @@ impl McpServer {
                             "properties": {
                                 "latitude": {"type": "number", "minimum": 48.7, "maximum": 49.0},
                                 "longitude": {"type": "number", "minimum": 2.0, "maximum": 2.6},
-                                "radius_meters": {"type": "integer", "minimum": 100, "maximum": 5000, "default": 500},
-                                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 10},
+                                "radius_meters": {
+                                    "type": "integer",
+                                    "minimum": 100,
+                                    "maximum": MAX_SEARCH_RADIUS,
+                                    "default": DEFAULT_RADIUS
+                                },
+                                "limit": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": MAX_RESULT_LIMIT,
+                                    "default": DEFAULT_LIMIT
+                                },
                                 "availability_filter": {"type": "object"}
                             },
                             "required": ["latitude", "longitude"]
@@ -248,7 +261,12 @@ impl McpServer {
                             "type": "object",
                             "properties": {
                                 "query": {"type": "string", "minLength": 2},
-                                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 10},
+                                "limit": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": MAX_RESULT_LIMIT,
+                                    "default": DEFAULT_LIMIT
+                                },
                                 "fuzzy": {"type": "boolean", "default": true}
                             },
                             "required": ["query"]

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -1,6 +1,29 @@
 use crate::types::{BikeTypeFilter, Coordinates, VelibStation};
 use serde::{Deserialize, Serialize};
 
+// ── Limit / default constants ────────────────────────────────────────────────
+// These are the single source of truth for all limit and default values used
+// by tool handlers, serde defaults, and the JSON schema advertised in
+// server.rs.  Update here; every consumer stays in sync automatically.
+
+/// Hard upper bound on the search radius accepted by `find_nearby_stations`.
+pub const MAX_SEARCH_RADIUS: u32 = 5_000; // 5 km
+
+/// Hard upper bound on the result count accepted by `find_nearby_stations` and
+/// `search_stations_by_name`.
+pub const MAX_RESULT_LIMIT: u16 = 100;
+
+/// Default search radius (metres) when the caller omits `radius_meters`.
+pub const DEFAULT_RADIUS: u32 = 500;
+
+/// Default result limit when the caller omits `limit`.
+pub const DEFAULT_LIMIT: u16 = 10;
+
+/// Default maximum walking distance (metres) for journey preferences.
+pub const DEFAULT_MAX_WALK: u32 = 500;
+
+// ── Availability filter ──────────────────────────────────────────────────────
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AvailabilityFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -89,10 +112,10 @@ pub struct FindNearbyStationsInput {
 }
 
 fn default_radius() -> u32 {
-    500
+    DEFAULT_RADIUS
 }
 fn default_tool_limit() -> u16 {
-    10
+    DEFAULT_LIMIT
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -135,7 +158,7 @@ pub struct JourneyPreferences {
 }
 
 fn default_max_walk() -> u32 {
-    500
+    DEFAULT_MAX_WALK
 }
 
 // MCP Tool Outputs


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `MAX_SEARCH_RADIUS`, `MAX_RESULT_LIMIT`, `DEFAULT_RADIUS`, `DEFAULT_LIMIT`, and `DEFAULT_MAX_WALK` were previously split across three files: raw integer literals in `server.rs`'s JSON schema, `const` definitions in `handlers.rs`, and inline literals in the `default_*()` serde helpers in `types.rs`.
- All five constants are now defined once as `pub const` at the top of `src/mcp/types.rs`.
- `handlers.rs` imports `MAX_SEARCH_RADIUS` and `MAX_RESULT_LIMIT` from `types` (the local `const` block is removed).
- `server.rs` imports all four constants and uses them directly inside the `json!({ ... })` schema block — no more magic numbers.
- The `default_radius()`, `default_tool_limit()`, and `default_max_walk()` serde helper functions now delegate to the named constants instead of containing their own literals.

## Test plan

- [ ] `cargo build` compiles without warnings on the changed files.
- [ ] `cargo test` passes — the existing unit tests in `handlers.rs` and `types.rs` exercise the same boundary values and should continue to pass unchanged.
- [ ] Manually verify `tools/list` response still advertises `"maximum": 5000` for `radius_meters` and `"maximum": 100` for `limit`.
- [ ] Confirm that changing a constant in `types.rs` (e.g. raising `MAX_RESULT_LIMIT` to 200) automatically propagates to both the handler validation and the advertised schema without any other edits required.
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_