### PR TITLE
docs(claude): tighten CLAUDE.md, drop stale phase list and aspirational metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,227 +1,82 @@
 # Projet CLAUDE : Serveur MCP Velib
 
 ## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP.
+Tu es un développeur Rust expert travaillant sur un projet open-source de
+serveur MCP exposant les jeux de données Velib Paris aux assistants IA.
 
-- **Répertoire de travail** : `~/code/velib-mcp/velib-mcp` (main repo)
-- **Architecture worktree** : Branches adjacentes (`~/code/velib-mcp/branch1/`, etc.)
 - **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
+- **Public cible** : assistants IA nécessitant l'accès aux données Velib
 
-### Structure du Projet
-```
-~/code/velib-mcp/
-├── velib-mcp/              # Dépôt principal (ce répertoire)
-│   ├── CLAUDE.md           # Configuration Claude partagée
-│   ├── src/                # Code source
-│   ├── docs/               # Documentation
-│   └── ...                 # Fichiers du projet
-├── branch1/                # Worktree pour branche feature
-│   ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-│   └── ...                 # Fichiers spécifiques à la branche
-└── branch2/                # Autre worktree
-    ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-    └── ...                 # Fichiers spécifiques à la branche
-```
+### Worktrees
+Le dépôt est cloné une fois ; les branches de fonctionnalité sont
+développées dans des worktrees adjacents partageant ce `CLAUDE.md` via
+symlink afin de garder un contexte cohérent.
 
-**Important** : Ce fichier CLAUDE.md est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
+```bash
+# Créer un worktree
+git worktree add ../<branch-name> <branch-name>
+ln -s ../velib-mcp/CLAUDE.md ../<branch-name>/CLAUDE.md
+
+# Supprimer un worktree
+git worktree remove ../<branch-name>
+git worktree prune
+```
 
 ## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
+Exposer via MCP les deux jeux de données Open Data Paris :
 
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
+- **Disponibilité temps réel** :
+  https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/
+- **Emplacements des stations** :
+  https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/
 
-- **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
+But : rendre l'information de ces datasets accessible aux assistants IA
+pour la planification des déplacements et l'analyse des flux.
 
-## État Actuel du Projet
+## État Actuel
+Le statut détaillé des phases vit dans
+[`docs/context/etat_actuel.md`](docs/context/etat_actuel.md). En résumé :
+phases 0 à 4 terminées, serveur déployé sur Scaleway via GitHub Actions,
+suite de tests automatisée (unitaires + intégration).
 
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
+### Architecture technique
+- Serveur MCP en Rust (transports HTTP `/mcp` et WebSocket `/mcp/ws`)
+- Deux datasets : disponibilité temps réel et emplacements de stations
+- Déploiement Scaleway Container Serverless via GitHub Actions
+- Validation de la zone de service (rayon 50 km autour de Paris)
 
-### Architecture Technique
-- **Serveur MCP Rust** pour données Velib Paris
-- **Deux datasets principaux** :
-  - Disponibilité stations en temps réel
-  - Localisations et métadonnées des stations
-- **Déploiement Scaleway** via GitHub Actions
-- **Suite de tests complète** (18+ tests)
-- **Validations sécurité** incluant limites zone service 50km
+### Fichiers importants
+- [`src/main.rs`](src/main.rs) — point d'entrée
+- [`src/mcp/`](src/mcp) — implémentation du protocole MCP
+- [`src/data/`](src/data) — client de données et cache
+- [`src/types.rs`](src/types.rs) — structures de données principales
+- [`docs/api/data_analysis.md`](docs/api/data_analysis.md) — analyse des datasets
+- [`docs/context/etat_actuel.md`](docs/context/etat_actuel.md) — suivi du statut
 
-### Fichiers Importants
-- `/src/main.rs` - Point d'entrée principal
-- `/src/mcp/` - Implémentation protocole MCP
-- `/src/data/` - Client données et cache
-- `/src/types.rs` - Structures de données principales
-- `/docs/api/data_analysis.md` - Analyse données complète
-- `/docs/context/etat_actuel.md` - Suivi statut projet
-
-### Commandes Développement
+## Commandes de développement
 ```bash
 cargo test                     # Tests complets
-cargo fmt                      # Formatage code
+cargo fmt                      # Formatage
 cargo clippy                   # Analyse statique
 cargo audit                    # Audit sécurité
 ```
 
-### Déploiement
+## Déploiement
 - **Cible** : Scaleway Container Serverless
-- **Déclencheur** : Push vers branche main
+- **Déclencheur** : push sur la branche `main`
 - **Registry** : Scaleway Container Registry
-- **Build** : Containerisation Podman
+- **Build** : containerisation Podman
 
-### Gestion Worktrees
-```bash
-# Créer nouveau worktree
-git worktree add ../branch-name branch-name
-cd ../branch-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
+## Processus de développement
+1. Issue GitHub décrivant la valeur métier et les critères de succès.
+2. Worktree dédié, tests d'intégration écrits avant l'implémentation
+   (TDD).
+3. Implémentation incrémentale validée localement à chaque commit
+   (`cargo clippy`, `cargo fmt`, `cargo test`).
+4. PR liée à l'issue, revue qualité (architecture, couverture, sécurité,
+   lisibilité), merge après approbation.
+5. Pipeline GitHub Actions assurant CI puis déploiement automatique.
 
-# Supprimer worktree
-git worktree remove ../branch-name
-git worktree prune
-```
-
-## Processus de Développement Multi-Agents
-
-### Architecture Optimisée pour Performance, Qualité et Autonomie
-
-Ce processus transforme l'approche linéaire traditionnelle en 5 phases parallèles pour maximiser l'efficacité d'équipe.
-
-#### Phase 1: Analyse Concurrente (PM + Test Designer)
-**Durée**: ~30 min | **Parallélisation**: PM et Test Designer travaillent simultanément
-
-**Product Manager (Rôle: Extraction de Valeur)**
-- Analyse issue GitHub avec template structuré
-- Extraction valeur métier claire et actionnable
-- Validation exigences avec dev-utilisateur
-- Production: Spécification fonctionnelle validée
-
-**Test Designer (Rôle: Planification Technique)**
-- Analyse technique parallèle de l'issue
-- Estimation nombre features/refactors uniques
-- Planification PRs et worktrees nécessaires
-- Production: Plan d'implémentation détaillé
-
-#### Phase 2: Fondation Tests (Test Designer)
-**Durée**: ~45 min | **Focus**: Environnement + Spécifications Test
-
-**Préparation Environnement**
-```bash
-# Création worktree optimisée avec template
-git worktree add ../feature-name feature/branch-name
-cd ../feature-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
-cargo test --no-run  # Pré-compilation dependencies
-```
-
-**Implémentation Tests TDD**
-- Tests d'intégration définissant comportement attendu
-- Tests unitaires pour composants critiques
-- Tests fuzz si applicable (données externes)
-- Validation: Tests échouent de manière attendue
-
-#### Phase 3: Sprint Implémentation (Ingénieur)
-**Durée**: Variable | **Focus**: Développement avec Validation Continue
-
-**Workflow Micro-Commits**
-```bash
-# Cycle développement optimisé
-while [[ $tests_failing ]]; do
-    # Implémentation incrémentale
-    cargo clippy --fix
-    cargo fmt
-    cargo test
-    git add -A && git commit -m "feat: micro-increment"
-done
-```
-
-**Intégration Continue Locale**
-- Validation automatique à chaque commit
-- Feedback temps réel des tests
-- Métriques qualité code continues
-- Résolution bloquants technique immédiate
-
-#### Phase 4: Révision Parallèle (Ingénieur + Réviseur)
-**Durée**: ~20 min | **Parallélisation**: Préparation + Analyse simultanées
-
-**Ingénieur (Préparation PR)**
-- Organisation commits en histoire cohérente
-- Rédaction description PR succincte
-- Validation finale checks locaux
-- Ouverture PR avec lien issue origine
-
-**Réviseur Senior (Analyse Qualité)**
-- Évaluation architecture et patterns Rust
-- Vérification couverture tests vs objectifs PM
-- Analyse lisibilité et extensibilité code
-- Validation sécurité et ergonomie
-
-**Boucle Feedback Structurée**
-- Critères évaluation standardisés
-- Dialogue constructif jusqu'accord
-- Résolution collaborative des points bloquants
-
-#### Phase 5: Intégration Automatisée (Ops)
-**Durée**: ~10 min | **Focus**: Déploiement et Validation
-
-**Merge et CI/CD**
-- Merge automatique post-approbation
-- Validation CI complète sur main
-- Monitoring santé déploiement
-- Métriques performance production
-
-### Templates et Checklists
-
-#### Template Analyse Issue (PM)
-```markdown
-## Valeur Métier
-- [ ] Problème utilisateur identifié
-- [ ] Solution proposée claire
-- [ ] Critères succès mesurables
-- [ ] Validation dev-utilisateur
-
-## Exigences Techniques
-- [ ] Contraintes techniques identifiées
-- [ ] Impact architecture évalué
-- [ ] Effort estimé (S/M/L/XL)
-```
-
-#### Checklist Qualité (Réviseur)
-```markdown
-## Architecture & Design
-- [ ] Patterns Rust idiomatiques respectés
-- [ ] Séparation responsabilités claire
-- [ ] Gestion erreurs appropriée
-- [ ] Performance optimisée
-
-## Tests & Couverture
-- [ ] Tests couvrent objectifs PM
-- [ ] Edge cases identifiés et testés
-- [ ] Intégration validée
-- [ ] Documentation à jour
-```
-
-### Métriques de Performance
-
-**Gains Attendus vs Processus Linéaire**
-- **Temps cycle**: -40% (parallélisation phases)
-- **Temps attente**: -60% (élimination handoffs)
-- **Qualité code**: +25% (validation continue)
-- **Autonomie équipe**: +50% (rôles auto-suffisants)
-
-### Intégration Architecture Existante
-
-Ce processus s'intègre parfaitement avec:
-- Architecture worktree existante (isolation parallèle)
-- CI/CD GitHub Actions (validation automatisée)
-- Hooks pre-commit (qualité continue)
-- Toolchain Rust standard (fmt, clippy, audit)
+Les hooks `cargo-husky` (`.cargo-husky/hooks/pre-commit`) reproduisent
+localement les checks bloquants : `cargo clippy --fix`, `cargo fmt`,
+`cargo sort`, `cargo deny check licenses bans sources`.


### PR DESCRIPTION
## Summary
- `CLAUDE.md` previously duplicated the phase status that lives in `docs/context/etat_actuel.md` and bundled a long "multi-agent" workflow section with invented performance metrics (`-40%`, `-60%`, `+25%`, `+50%`) that did not reflect how this repository is actually developed. It also carried checkmark emojis on the phase list and a hard-coded `~/code/velib-mcp/...` working-directory path.
- Tightened the file to: role, worktree usage, datasets, a link to the canonical status doc, key files as repo-relative file pointers, commands, deploy target, and the real TDD + `cargo-husky` workflow.
- No information unique to `CLAUDE.md` is dropped; phase details remain available in `docs/context/etat_actuel.md`.

## Test plan
- [ ] Skim diff to confirm no information unique to `CLAUDE.md` was lost.
- [ ] Verify the file pointers in `CLAUDE.md` (`src/main.rs`, `src/mcp/`, `src/data/`, `src/types.rs`, `docs/api/data_analysis.md`, `docs/context/etat_actuel.md`) all resolve.
- [ ] Confirm CI passes (no code changes, docs-only).

https://claude.ai/code/session_01C5q6TXtM8gokDqpRTMWRe5

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5q6TXtM8gokDqpRTMWRe5)_