### PR TITLE
refactor(retry): inline single-use public helpers into check_response

### DIFF
--- a/src/data/retry.rs
+++ b/src/data/retry.rs
@@ -240,23 +240,6 @@ impl Default for RetryPolicy {
     }
 }
 
-/// Helper function to extract retry-after header from reqwest error
-pub fn extract_retry_after_from_response(response: &reqwest::Response) -> Option<u64> {
-    response
-        .headers()
-        .get("retry-after")
-        .and_then(|value| value.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-}
-
-/// Helper function to create rate limited error from HTTP response
-pub fn create_rate_limited_error(response: &reqwest::Response) -> Error {
-    let retry_after = extract_retry_after_from_response(response);
-    Error::RateLimited {
-        retry_after_seconds: retry_after,
-    }
-}
-
 /// Wrapper for making HTTP requests with retry logic
 #[derive(Debug)]
 pub struct RetryableHttpClient {
@@ -286,13 +269,20 @@ impl RetryableHttpClient {
         debug!("Received response: {} {}", response.status(), url);
 
         if response.status() == 429 {
-            let retry_after = extract_retry_after_from_response(&response);
+            let retry_after_seconds = response
+                .headers()
+                .get("retry-after")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok());
             warn!(
                 "Rate limited (429) for {}{}",
                 url,
-                retry_after.map_or_else(String::new, |seconds| format!(", retry after {seconds}s"))
+                retry_after_seconds
+                    .map_or_else(String::new, |seconds| format!(", retry after {seconds}s"))
             );
-            return Err(create_rate_limited_error(&response));
+            return Err(Error::RateLimited {
+                retry_after_seconds,
+            });
         }
 
         if !response.status().is_success() {


### PR DESCRIPTION
## Summary

`src/data/retry.rs` exposes two `pub` free functions, `extract_retry_after_from_response` and `create_rate_limited_error`, that:

- Have a single internal caller, `RetryableHttpClient::check_response`.
- Have zero external consumers anywhere in the workspace (verified via repo-wide search).
- Together encode the same two-step "read `retry-after` header -> build `Error::RateLimited`" flow that `check_response` immediately performs.

This PR inlines both into `check_response` as one self-contained block on the 429 branch. It removes ~12 lines of public surface area and one redundant level of indirection.

## Architectural precept this serves

CLAUDE.md, "Checklist Qualité (Réviseur) -- Architecture & Design":
- "Patterns Rust idiomatiques respectés" -- `pub` should be reserved for boundary types and intentional extension points.
- "Séparation responsabilités claire" -- helpers with one caller and no consumers blur, not clarify, ownership.

## Behavior

Identical. The 429 path:
1. parses `retry-after` header into `Option<u64>` (same logic, lifted into `check_response`),
2. logs `warn!` with the same template,
3. returns `Error::RateLimited { retry_after_seconds }`.

The `Display` test for `Error::RateLimited` in `src/error.rs` continues to cover end-to-end formatting of both the `Some(seconds)` and `None` branches.

## Test plan

- [ ] `cargo test` passes (no test changes; existing retry, error, and rate-limited tests cover the inlined path)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo fmt --check` clean

https://claude.ai/code/session_eloquent-bardeen-Ed9Km

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4jqYEaszguJ91VUxtR3XV)_