### PR TITLE
docs: fix Claude Code MCP install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ A high-performance Model Context Protocol (MCP) server providing access to Paris
 Install and use the Velib MCP server with Claude Code in one command:
 
 ```bash
-# Install and configure the server
+# Install the server binary
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-claude config add-server velib-mcp "cargo run --release -- --port 3000"
+# Register it with Claude Code
+claude mcp add velib-mcp -- velib-mcp
 ```
 
 Then use in Claude Code:


### PR DESCRIPTION
## Summary
- The README's Quick Start invoked `claude config add-server`, which is **not** a real Claude Code CLI subcommand and would fail when copy-pasted by a user. The correct command is `claude mcp add <name> -- <command>` (per the official Claude Code MCP docs).
- The same snippet also told users to launch the server with `cargo run --release --port 3000`, but after `cargo install` there is no local checkout for `cargo run` to operate on. Replaced it with the installed `velib-mcp` binary.
- Net change: 2 README lines, no code touched.

## Before
```bash
cargo install --git https://github.com/dominicburkart/velib-mcp.git
claude config add-server velib-mcp "cargo run --release -- --port 3000"
```

## After
```bash
cargo install --git https://github.com/dominicburkart/velib-mcp.git
claude mcp add velib-mcp -- velib-mcp
```

## Test plan
- [ ] Run `claude mcp add velib-mcp -- velib-mcp` after `cargo install` and confirm the server registers and responds to tool calls
- [ ] Confirm `claude mcp list` shows the server

https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6)_