### PR TITLE
docs: tighten and correct stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,31 +38,23 @@ Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA
 
 ## État Actuel du Projet
 
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
+Statut détaillé (phases, interfaces livrées) : voir
+[`docs/context/etat_actuel.md`](docs/context/etat_actuel.md).
 
 ### Architecture Technique
-- **Serveur MCP Rust** pour données Velib Paris
-- **Deux datasets principaux** :
-  - Disponibilité stations en temps réel
-  - Localisations et métadonnées des stations
-- **Déploiement Scaleway** via GitHub Actions
-- **Suite de tests complète** (18+ tests)
-- **Validations sécurité** incluant limites zone service 50km
+- Serveur MCP Rust, JSON-RPC 2.0 sur HTTP `/mcp` et WebSocket `/mcp/ws`
+- Deux datasets : disponibilité temps réel et emplacements des stations
+- Déploiement Scaleway Container Serverless via GitHub Actions
+- Validation des coordonnées : bornes Paris métropole + rayon 50km
+  ([`Coordinates`](src/types.rs))
 
 ### Fichiers Importants
-- `/src/main.rs` - Point d'entrée principal
-- `/src/mcp/` - Implémentation protocole MCP
-- `/src/data/` - Client données et cache
-- `/src/types.rs` - Structures de données principales
-- `/docs/api/data_analysis.md` - Analyse données complète
-- `/docs/context/etat_actuel.md` - Suivi statut projet
+- [`src/main.rs`](src/main.rs) — point d'entrée
+- [`src/mcp/`](src/mcp) — protocole MCP (handlers, server, types)
+- [`src/data/`](src/data) — client et cache
+- [`src/types.rs`](src/types.rs) — structures partagées
+- [`docs/api/data_analysis.md`](docs/api/data_analysis.md) — analyse données
+- [`docs/api/mcp_interface_spec.md`](docs/api/mcp_interface_spec.md) — interface MCP
 
 ### Commandes Développement
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ A high-performance Model Context Protocol (MCP) server providing access to Paris
 
 ## Quick Start - Install with Claude Code
 
-Install and use the Velib MCP server with Claude Code in one command:
+Install the binary and register it with Claude Code:
 
 ```bash
-# Install and configure the server
+# Install the server (provides the `velib-mcp` binary)
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-claude config add-server velib-mcp "cargo run --release -- --port 3000"
+# Register with Claude Code (default port 8080; override with PORT env var)
+claude mcp add velib-mcp velib-mcp
 ```
 
 Then use in Claude Code:
@@ -50,44 +51,32 @@ This project exposes two key Parisian datasets through MCP:
 <details>
 <summary>Click to expand integration guides</summary>
 
-### ChatGPT
+All clients run the same `velib-mcp` binary, which listens on `0.0.0.0:8080`
+by default (override with the `PORT` environment variable; no CLI flags).
+
 ```bash
-# Install server
 cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server on port 8080
-velib-mcp
-# Configure in ChatGPT Custom Instructions or use via API
+PORT=8080 velib-mcp
 ```
 
+### ChatGPT
+Configure in ChatGPT Custom Instructions or use via API.
+
 ### Cursor
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Add to Cursor's settings.json
+Add to Cursor's `settings.json`:
+```json
 {
   "mcp.servers": {
-    "velib": {
-      "command": "velib-mcp",
-      "args": ["--port", "8080"]
-    }
+    "velib": { "command": "velib-mcp" }
   }
 }
 ```
 
 ### Le Chat / Mistral
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server and use via API calls
-velib-mcp --port 8080
-```
+Run `velib-mcp` and use via API calls.
 
 ### Windsurf
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Configure in Windsurf MCP settings
-```
+Configure in Windsurf MCP settings.
 
 </details>
 
@@ -132,14 +121,17 @@ enforces:
 
 Any non-zero exit aborts the commit.
 
-### Podman
+### Container image
+
+The container image is produced by the Nix flake (no Dockerfile):
 
 ```bash
-# Build container image
-podman build -t velib-mcp .
+# Build the image and load into Podman/Docker
+nix build .#container
+podman load < result    # or: docker load -i result
 
-# Run container
-podman run -p 8080:8080 velib-mcp
+# Run
+podman run -p 8080:8080 velib-mcp:latest
 ```
 
 ## Deployment

--- a/docs/api/data_analysis.md
+++ b/docs/api/data_analysis.md
@@ -1,4 +1,4 @@
-# Analyse des Données Velib - Phase 1
+# Analyse des Données Velib
 
 ## Vue d'ensemble
 

--- a/docs/api/mcp_interface_spec.md
+++ b/docs/api/mcp_interface_spec.md
@@ -19,20 +19,13 @@ Ce document définit les interfaces MCP (Model Context Protocol) exposées par l
 
 ## Resources MCP
 
+Toutes les resources renvoient `application/json`. Voir
+[`src/mcp/server.rs`](../../src/mcp/server.rs) pour le routage.
+
 ### 1. Stations de Référence
 
-#### Resource URI
-```
-velib://stations/reference
-```
-
-#### Description
-Catalogue complet des stations Velib avec leurs métadonnées statiques.
-
-#### Content Type
-```
-application/json
-```
+URI : `velib://stations/reference` — catalogue complet des stations Velib
+avec leurs métadonnées statiques.
 
 #### Exemple de Contenu
 ```json
@@ -58,18 +51,8 @@ application/json
 
 ### 2. Disponibilité Temps Réel
 
-#### Resource URI
-```
-velib://stations/realtime
-```
-
-#### Description
-État actuel de toutes les stations avec disponibilité des vélos et emplacements.
-
-#### Content Type
-```
-application/json
-```
+URI : `velib://stations/realtime` — état actuel de toutes les stations
+avec disponibilité des vélos et emplacements.
 
 #### Exemple de Contenu
 ```json
@@ -100,30 +83,18 @@ application/json
 
 ### 3. Stations Consolidées
 
-#### Resource URI
-```
-velib://stations/complete
-```
-
-#### Description
-Vue complète combinant données de référence et temps réel.
-
-#### Content Type
-```
-application/json
-```
+URI : `velib://stations/complete` — vue complète combinant données de
+référence et temps réel.
 
 ## Tools MCP
 
+Les handlers sont implémentés dans
+[`src/mcp/handlers.rs`](../../src/mcp/handlers.rs).
+
 ### 1. Recherche de Stations Proches
 
-#### Tool Name
-```
-find_nearby_stations
-```
-
-#### Description
-Trouve les stations Velib dans un rayon donné autour d'un point.
+Tool : [`find_nearby_stations`](../../src/mcp/handlers.rs#L153) — trouve
+les stations Velib dans un rayon donné autour d'un point.
 
 #### Input Schema
 ```json
@@ -231,13 +202,8 @@ Trouve les stations Velib dans un rayon donné autour d'un point.
 
 ### 2. Obtenir Station par Code
 
-#### Tool Name
-```
-get_station_by_code
-```
-
-#### Description
-Récupère les informations complètes d'une station spécifique.
+Tool : [`get_station_by_code`](../../src/mcp/handlers.rs#L212) —
+récupère les informations complètes d'une station spécifique.
 
 #### Input Schema
 ```json
@@ -277,13 +243,8 @@ Récupère les informations complètes d'une station spécifique.
 
 ### 3. Recherche par Nom de Station
 
-#### Tool Name
-```
-search_stations_by_name
-```
-
-#### Description
-Recherche textuelle dans les noms de stations.
+Tool : [`search_stations_by_name`](../../src/mcp/handlers.rs#L227) —
+recherche textuelle dans les noms de stations.
 
 #### Input Schema
 ```json
@@ -314,13 +275,8 @@ Recherche textuelle dans les noms de stations.
 
 ### 4. Statistiques de Zone
 
-#### Tool Name
-```
-get_area_statistics
-```
-
-#### Description
-Calcule des statistiques agrégées pour une zone géographique.
+Tool : [`get_area_statistics`](../../src/mcp/handlers.rs#L286) —
+calcule des statistiques agrégées pour une zone géographique.
 
 #### Input Schema
 ```json
@@ -381,13 +337,8 @@ Calcule des statistiques agrégées pour une zone géographique.
 
 ### 5. Itinéraire avec Vélos
 
-#### Tool Name
-```
-plan_bike_journey
-```
-
-#### Description
-Planifie un trajet en suggérant stations de départ et d'arrivée.
+Tool : [`plan_bike_journey`](../../src/mcp/handlers.rs#L303) — planifie
+un trajet en suggérant stations de départ et d'arrivée.
 
 #### Input Schema
 ```json
@@ -471,51 +422,37 @@ Planifie un trajet en suggérant stations de départ et d'arrivée.
 
 ## Gestion des Erreurs
 
-### Codes d'Erreur Standard
+Les codes JSON-RPC suivent le mapping défini dans
+[`Error::mcp_error_code`](../../src/error.rs#L49). Exemple :
+
 ```json
 {
   "error": {
-    "code": -32001,
-    "message": "Station not found",
+    "code": -32600,
+    "message": "Station not found: 99999",
     "data": {
       "station_code": "99999",
-      "error_type": "STATION_NOT_FOUND"
+      "error_type": "station_not_found"
     }
   }
 }
 ```
 
-### Types d'Erreurs
-- `-32001` : Station non trouvée
-- `-32002` : Coordonnées invalides  
-- `-32003` : Données temps réel indisponibles
-- `-32004` : Rayon de recherche trop large
-- `-32005` : Limite de résultats dépassée
+### Mapping des codes
+- `-32700` : erreur de parsing JSON
+- `-32600` : requête invalide (`StationNotFound`)
+- `-32602` : paramètres invalides (`InvalidCoordinates`,
+  `OutsideServiceArea`, `SearchRadiusTooLarge`, `ResultLimitExceeded`,
+  `Validation`)
+- `-32603` : erreur interne (`McpProtocol`, `Cache`, `Internal`)
+- `-32001` : erreur serveur (`Http`, `RateLimited`)
 
-## Rate Limiting
+## Authentification et Rate Limiting
 
-### Limites par Défaut
-- **Resources** : 60 requêtes/minute
-- **Tools** : 100 requêtes/minute
-- **Burst** : 10 requêtes/seconde
-
-### Headers de Réponse
-```
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1640995200
-```
-
-## Authentification
-
-### Mode Public
-- Aucune authentification requise
-- Rate limiting appliqué par IP
-
-### Mode API Key (Futur)
-```http
-Authorization: Bearer <api_key>
-```
+Non implémentés à ce jour : aucune authentification n'est requise et
+aucun en-tête `X-RateLimit-*` n'est émis. Le client API amont
+(`opendata.paris.fr`) peut renvoyer un HTTP 429 ; ce cas remonte sous
+forme de `Error::RateLimited`.
 
 ## Métadonnées de Santé
 

--- a/docs/api/mcp_schemas.md
+++ b/docs/api/mcp_schemas.md
@@ -134,16 +134,16 @@ pub struct VelibStation {
     pub data_freshness: DataFreshness,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+// Définition réelle dans `src/types.rs` :
+// `Fresh` (< 10 min), `Recent` (10-30 min), `Stale` (30-120 min),
+// `VeryStale` (> 120 min). Voir
+// [`DataFreshness::from_age`](../../src/types.rs#L146).
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DataFreshness {
-    /// Données très récentes (< 2 minutes)
     Fresh,
-    /// Données acceptables (< 5 minutes)
-    Acceptable,
-    /// Données anciennes (> 5 minutes)
+    Recent,
     Stale,
-    /// Données indisponibles
-    Unavailable,
+    VeryStale,
 }
 ```
 


### PR DESCRIPTION
## Summary

Conservative documentation pass to remove stale references, dedupe, and standardize code pointers as `[label](path#Lnnn)`. No information dropped.

### Stale-vs-code corrections
- **README** — `claude config add-server ...` is not a real command; replaced with `claude mcp add`. The binary takes no `--port` CLI flag (uses `PORT` env var per `src/server/config.rs`); per-client snippets passing `--port 8080` removed. The "Podman" section's `podman build -t velib-mcp .` would fail (no Dockerfile in the repo); image is built via the Nix flake (`nix build .#container`) per `.github/workflows/deploy.yml`.
- **docs/api/mcp_interface_spec.md** — error codes `-32001..-32005` and the rate-limit/auth sections describe behavior that does not exist in `src/error.rs` or `src/mcp/server.rs`. Replaced with the real mapping from [`Error::mcp_error_code`](../../src/error.rs#L49) and a short "not implemented" note for auth/rate-limit (the upstream 429 path is preserved as `Error::RateLimited`). Added `[handler](src/mcp/handlers.rs#Lnnn)` pointers for each tool.
- **docs/api/mcp_schemas.md** — `DataFreshness` variants corrected to match `src/types.rs`: `Fresh / Recent / Stale / VeryStale` (was `Fresh / Acceptable / Stale / Unavailable`).
- **docs/api/data_analysis.md** — title no longer claims "Phase 1" (all phases complete per `docs/context/etat_actuel.md`).

### Dedupe / tightening
- **CLAUDE.md** — phase-by-phase status list duplicated `docs/context/etat_actuel.md`; replaced with a single pointer. "Important Files" list switched to `[label](path)` form.
- **README** — integration-guide block per AI client repeated the same `cargo install` four times; lifted to a single shared snippet.

## Test plan
- [ ] Verify the `claude mcp add` command snippet is what users currently run.
- [ ] Confirm the Nix container build instructions work end-to-end.
- [ ] Check rendered links in `docs/api/mcp_interface_spec.md` and `mcp_schemas.md` resolve to the right line numbers.

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_