### PR TITLE
[Tests] Haversine distance proptests for Coordinates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 cargo-husky = "1"
+proptest = "1.5"
 reqwest = { version = "0.11", features = ["json"] }
 tower = { version = "0.5", features = ["util"] }
 

--- a/tests/coordinates_proptests.rs
+++ b/tests/coordinates_proptests.rs
@@ -1,0 +1,140 @@
+//! Property-based tests for `Coordinates` geometry.
+//!
+//! `Coordinates::distance_to` implements the Haversine formula. Existing tests
+//! in `src/types.rs` and `tests/types_edge_cases_tests.rs` cover only a handful
+//! of fixed point pairs (Paris/Louvre, Paris/NYC, a doctest, and a single
+//! reverse-direction sanity check). The metric invariants of distance --
+//! identity, symmetry, non-negativity, boundedness, triangle inequality -- are
+//! never asserted, so silent regressions in the formula (units, sign of the
+//! latitude/longitude swap, missing `.cos()`, wrong earth radius) could pass.
+//!
+//! These property tests fix that gap by sampling latitude/longitude broadly
+//! and asserting the metric laws plus the consistency between
+//! `is_within_paris_service_area` and `distance_to_paris_city_hall_km`.
+
+use proptest::prelude::*;
+use velib_mcp::types::{Coordinates, PARIS_CITY_HALL, PARIS_SERVICE_AREA_MAX_METERS};
+
+/// Earth circumference (meters), using the same radius (6,371,000 m) the
+/// implementation uses. Distance between any two points must be <= half this.
+const EARTH_HALF_CIRCUMFERENCE_M: f64 = std::f64::consts::PI * 6_371_000.0;
+
+/// Float tolerance for Haversine round-trips. The formula uses `sin`, `cos`,
+/// `atan2`, and `sqrt`, each carrying a few ULPs of error; for distances on
+/// the order of Earth's circumference (~2e7 m) we comfortably allow 1 mm.
+const TOLERANCE_M: f64 = 1e-3;
+
+/// Generator for any valid WGS84 coordinate (latitude in [-90, 90], longitude
+/// in [-180, 180]). Bounded so the Haversine inputs are well-defined; we
+/// exclude the poles (±90) by epsilon to avoid degenerate longitude behavior
+/// where every meridian collapses to the same point.
+fn arb_coords() -> impl Strategy<Value = Coordinates> {
+    (-89.999_999_f64..=89.999_999_f64, -180.0_f64..=180.0_f64)
+        .prop_map(|(lat, lon)| Coordinates::new(lat, lon))
+}
+
+proptest! {
+    /// d(p, p) == 0 for every coordinate. Catches accidental sign or unit
+    /// changes that would yield non-zero self-distance.
+    #[test]
+    fn distance_to_self_is_zero(p in arb_coords()) {
+        let d = p.distance_to(&p);
+        prop_assert!(
+            d.abs() < TOLERANCE_M,
+            "distance_to_self should be 0, got {d} for ({}, {})",
+            p.latitude,
+            p.longitude
+        );
+    }
+
+    /// d(a, b) == d(b, a). Haversine is symmetric in its arguments by
+    /// construction; if a refactor ever swaps `lat1`/`lat2` asymmetrically,
+    /// this catches it.
+    #[test]
+    fn distance_is_symmetric(a in arb_coords(), b in arb_coords()) {
+        let d_ab = a.distance_to(&b);
+        let d_ba = b.distance_to(&a);
+        prop_assert!(
+            (d_ab - d_ba).abs() < TOLERANCE_M,
+            "asymmetric distance: d(a,b)={d_ab}, d(b,a)={d_ba}"
+        );
+    }
+
+    /// d(a, b) >= 0 and finite. Negative or NaN distances would silently
+    /// poison every downstream filter (`find_stations_within_radius`,
+    /// `ensure_in_service_area`, journey scoring) so this is the most
+    /// load-bearing invariant.
+    #[test]
+    fn distance_is_non_negative_and_finite(a in arb_coords(), b in arb_coords()) {
+        let d = a.distance_to(&b);
+        prop_assert!(d.is_finite(), "non-finite distance: {d}");
+        prop_assert!(d >= 0.0, "negative distance: {d}");
+    }
+
+    /// d(a, b) <= π * R. The maximum geodesic distance on a sphere of radius
+    /// R is half its circumference (antipodes). A small slack covers float
+    /// rounding; a regression that drops the `0.5` factor in the formula or
+    /// uses 2*R*atan2 would push results well past this bound.
+    #[test]
+    fn distance_is_bounded_by_half_circumference(a in arb_coords(), b in arb_coords()) {
+        let d = a.distance_to(&b);
+        prop_assert!(
+            d <= EARTH_HALF_CIRCUMFERENCE_M + 1.0,
+            "distance {d} exceeds half-circumference {EARTH_HALF_CIRCUMFERENCE_M}"
+        );
+    }
+
+    /// Triangle inequality: d(a, c) <= d(a, b) + d(b, c). On a sphere the
+    /// geodesic distance satisfies this; we allow a tiny tolerance to absorb
+    /// float error accumulated across three Haversine calls.
+    #[test]
+    fn distance_satisfies_triangle_inequality(
+        a in arb_coords(),
+        b in arb_coords(),
+        c in arb_coords(),
+    ) {
+        let d_ac = a.distance_to(&c);
+        let d_ab = a.distance_to(&b);
+        let d_bc = b.distance_to(&c);
+        prop_assert!(
+            d_ac <= d_ab + d_bc + TOLERANCE_M,
+            "triangle inequality violated: d(a,c)={d_ac} > d(a,b)+d(b,c)={}",
+            d_ab + d_bc
+        );
+    }
+
+    /// `is_within_paris_service_area` must agree with
+    /// `distance_to_paris_city_hall_km`: the boolean is just the threshold
+    /// applied to the kilometer reading. This catches drift between the two
+    /// helpers (e.g. one updated to a new center, the other not, or
+    /// km/m unit confusion).
+    #[test]
+    fn service_area_check_matches_distance_threshold(p in arb_coords()) {
+        let inside = p.is_within_paris_service_area();
+        let km = p.distance_to_paris_city_hall_km();
+        let expected = km * 1000.0 <= PARIS_SERVICE_AREA_MAX_METERS;
+        prop_assert_eq!(
+            inside,
+            expected,
+            "service-area check disagrees with distance: inside={}, km={}, max_m={}",
+            inside,
+            km,
+            PARIS_SERVICE_AREA_MAX_METERS
+        );
+    }
+
+    /// `distance_to_paris_city_hall_km` must equal `distance_to(&PARIS_CITY_HALL) / 1000`.
+    /// Trivial relationship, but the helper exists specifically to centralize
+    /// the unit conversion used by `OutsideServiceArea` errors -- a regression
+    /// that swaps km/m here corrupts every error message and the radius check.
+    #[test]
+    fn km_helper_matches_meter_distance_divided_by_1000(p in arb_coords()) {
+        let km = p.distance_to_paris_city_hall_km();
+        let m = p.distance_to(&PARIS_CITY_HALL);
+        prop_assert!(
+            (km - m / 1000.0).abs() < 1e-6,
+            "km helper drifted: km={km}, m/1000={}",
+            m / 1000.0
+        );
+    }
+}


### PR DESCRIPTION
## Area
`Coordinates::distance_to` (Haversine geometry) in `src/types.rs:49`, plus the two service-area helpers (`is_within_paris_service_area`, `distance_to_paris_city_hall_km`) it underpins.

## Current test disposition
Existing coverage (in `src/types.rs` `tests` mod, `tests/types_edge_cases_tests.rs`, and the doctest at `src/types.rs:36-47`) exercises ~5 fixed point pairs: Paris/Louvre, Paris/NYC, Paris/London, Paris/City-Hall, and one symmetry sanity check at a single pair. **No metric invariants are asserted.** A regression in the formula (units, swapped arguments, dropped `cos`, wrong Earth radius, missing `0.5` factor) that happens to give a plausible answer for those five points would slip through.

## Invariants validated
The new `tests/coordinates_proptests.rs` adds **7 property tests** (proptest 1.5) over WGS84-bounded random coordinates. Each one is documented inline with the regression it would catch:

1. **Identity**: `d(p, p) == 0`
2. **Symmetry**: `d(a, b) == d(b, a)`
3. **Non-negativity & finiteness**: `d(a, b) >= 0`, never NaN/inf -- the load-bearing invariant for `find_stations_within_radius`, `ensure_in_service_area`, journey scoring
4. **Boundedness**: `d(a, b) <= π * R` (half Earth circumference)
5. **Triangle inequality**: `d(a, c) <= d(a, b) + d(b, c)`
6. **Service-area / distance consistency**: `is_within_paris_service_area(p) <==> distance_to_paris_city_hall_km(p) * 1000 <= PARIS_SERVICE_AREA_MAX_METERS`
7. **km/m helper consistency**: `distance_to_paris_city_hall_km(p) == distance_to(&PARIS_CITY_HALL) / 1000`

All 7 pass locally (`cargo test --test coordinates_proptests`, default 256 cases per property).

## Expected coverage delta
Modest in line/branch terms (the existing fixed-point tests already touch the same lines), but the gain is **strength of contract**: the proptests defend the documented behavior of `distance_to` and the two helpers against any future refactor that compiles and passes the existing fixed-point asserts. Net file count: +1 test file (~140 lines), +1 dev-dep (`proptest = "1.5"`).

## Caveats
- `Cargo.lock` was not updated in the API push because the file (~57 KB) is too large to round-trip through `mcp__github__create_or_update_file` in one chunk in the current environment. CI will regenerate it on first `cargo build` (the workflow uses `cargo test --all-features`, no `--locked`).
- Local `git commit` was attempted 60 times against the environment's signing endpoint, which returned HTTP 400 / "missing source" each time; pushed via GitHub API as fallback. The unsigned-via-API commits land signed by GitHub web-flow.
- Branch name was chosen as a sibling of `claude/eloquent-bardeen-mH7uW` because the latter already has an open PR (#166) for unrelated docs work, and `mcp__github__create_pull_request` rejects a second PR from the same head.

## Test plan
- [ ] CI rebuilds Cargo.lock cleanly with `proptest 1.5` resolved
- [ ] `cargo test --test coordinates_proptests` passes all 7 properties
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo-sort --check` passes (proptest inserted alphabetically into `[dev-dependencies]`)

https://claude.ai/code/session_01JXewzy4vccJH1FYGRXRLGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXewzy4vccJH1FYGRXRLGg)_