### PR TITLE
docs: tighten clarity in CLAUDE.md, README, and status doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,219 +1,89 @@
 # Projet CLAUDE : Serveur MCP Velib
 
 ## Contexte et Rôle
-Tu es un développeur Rust expert travaillant sur un projet open-source de serveur MCP.
+Développeur Rust expert sur un projet open-source de serveur MCP donnant
+accès aux données Velib Paris pour assistants IA.
 
-- **Répertoire de travail** : `~/code/velib-mcp/velib-mcp` (main repo)
-- **Architecture worktree** : Branches adjacentes (`~/code/velib-mcp/branch1/`, etc.)
-- **Outils disponibles** : git, cargo, podman, CLI scw, CLI gh
-- **Public cible** : Assistants IA nécessitant l'accès aux données Velib
-- **Durée prévue** : Projet de développement multi-jour
-- **Contexte** : Développement collaboratif avec possibilité de travail parallèle sur différents worktrees
-
-### Structure du Projet
-```
-~/code/velib-mcp/
-├── velib-mcp/              # Dépôt principal (ce répertoire)
-│   ├── CLAUDE.md           # Configuration Claude partagée
-│   ├── src/                # Code source
-│   ├── docs/               # Documentation
-│   └── ...                 # Fichiers du projet
-├── branch1/                # Worktree pour branche feature
-│   ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-│   └── ...                 # Fichiers spécifiques à la branche
-└── branch2/                # Autre worktree
-    ├── CLAUDE.md -> ../velib-mcp/CLAUDE.md  # Symlink vers config principale
-    └── ...                 # Fichiers spécifiques à la branche
-```
-
-**Important** : Ce fichier CLAUDE.md est partagé via symlinks vers tous les worktrees pour maintenir un contexte cohérent.
+- **Outils** : git, cargo, podman, CLI `scw`, CLI `gh`
+- **Public cible** : Assistants IA consommant des données Velib
+- **Worktrees** : support des branches adjacentes via `git worktree`. Si un
+  worktree est créé, le `CLAUDE.md` racine est partagé via symlink pour
+  préserver le contexte.
 
 ## Objectif du Projet
-Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA les deux jeux de données parisiens suivants :
+Serveur cloud MCP performant exposant les deux jeux de données Velib
+publiés par la Ville de Paris :
 
-- **Disponibilité temps réel** : https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/information/?disjunctive.is_renting&disjunctive.is_installed&disjunctive.is_returning&disjunctive.name&disjunctive.nom_arrondissement_communes
-- **Emplacements des stations** : https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/information/
+- [Disponibilité temps réel](https://opendata.paris.fr/explore/dataset/velib-disponibilite-en-temps-reel/)
+- [Emplacements des stations](https://opendata.paris.fr/explore/dataset/velib-emplacement-des-stations/)
 
-- **But** : Rendre toute information possible de ces jeux de données accessible aux assistants IA pour la planification des transports et l'analyse des flux de trajets.
+Le but est de rendre l'intégralité de ces jeux exploitable par des
+assistants IA pour la planification de trajets et l'analyse des flux.
 
-## État Actuel du Projet
+## État du Projet
 
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
+Les phases planifiées (0 à 4) sont terminées. Pour le détail des
+livrables, des interfaces MCP exposées et des évolutions en cours, voir
+[`docs/context/etat_actuel.md`](docs/context/etat_actuel.md).
 
-### Architecture Technique
-- **Serveur MCP Rust** pour données Velib Paris
-- **Deux datasets principaux** :
-  - Disponibilité stations en temps réel
-  - Localisations et métadonnées des stations
-- **Déploiement Scaleway** via GitHub Actions
-- **Suite de tests** : unitaires + intégration, exécutée par `cargo test`
-- **Validations sécurité** incluant limites zone service 50km
+### Repères dans le code
+- `src/main.rs` — point d'entrée
+- `src/mcp/` — implémentation du protocole MCP
+- `src/data/` — client API et cache TTL
+- `src/types.rs` — structures de données partagées
+- `docs/api/data_analysis.md` — analyse complète des datasets
+- `docs/api/mcp_interface_spec.md` — spécification des tools et resources
 
-### Fichiers Importants
-- `src/main.rs` — point d'entrée principal
-- `src/mcp/` — implémentation protocole MCP
-- `src/data/` — client données et cache
-- `src/types.rs` — structures de données principales
-- `docs/api/data_analysis.md` — analyse données complète
-- `docs/context/etat_actuel.md` — suivi statut projet
+## Commandes Développement
 
-### Commandes Développement
 ```bash
-cargo test                     # Tests complets
-cargo fmt                      # Formatage code
-cargo clippy                   # Analyse statique
-cargo audit                    # Audit sécurité
+cargo test                                            # tests complets
+cargo fmt --all                                       # formatage
+cargo clippy --all-targets --all-features -- -D warnings
+cargo audit                                           # audit sécurité
+cargo deny check licenses bans sources                # conformité licences
 ```
 
-### Déploiement
+Le hook `pre-commit` installé par `cargo-husky` reproduit `clippy --fix`,
+`fmt`, `cargo sort` et `cargo deny`. Un échec non nul du hook avorte le
+commit.
+
+## Déploiement
 - **Cible** : Scaleway Container Serverless
-- **Déclencheur** : Push vers branche main
+- **Déclencheur** : push sur `main`
 - **Registry** : Scaleway Container Registry
-- **Build** : Containerisation Podman
+- **Build** : containerisation Podman (image distroless Debian)
 
-### Gestion Worktrees
+## Gestion des Worktrees
+
 ```bash
-# Créer nouveau worktree
-git worktree add ../branch-name branch-name
-cd ../branch-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
+# Créer un worktree pour une branche feature
+git worktree add ../branch-name feature/branch-name
+ln -s ../velib-mcp/CLAUDE.md ../branch-name/CLAUDE.md
 
-# Supprimer worktree
+# Supprimer un worktree
 git worktree remove ../branch-name
 git worktree prune
 ```
 
-## Processus de Développement Multi-Agents
+## Processus de Développement
 
-### Architecture Optimisée pour Performance, Qualité et Autonomie
+Le flux typique pour une issue est :
 
-Ce processus transforme l'approche linéaire traditionnelle en 5 phases parallèles pour maximiser l'efficacité d'équipe.
+1. **Analyse** — extraire la valeur métier, identifier les contraintes
+   techniques et estimer l'effort (S/M/L/XL).
+2. **Tests d'abord** — écrire les tests d'intégration et unitaires
+   décrivant le comportement attendu ; vérifier qu'ils échouent.
+3. **Implémentation incrémentale** — micro-commits validés localement par
+   `cargo clippy`, `cargo fmt`, `cargo test`.
+4. **Revue** — ouvrir une PR liée à l'issue, vérifier patterns Rust
+   idiomatiques, couverture, lisibilité, sécurité.
+5. **Merge et CI** — après approbation, le merge sur `main` déclenche le
+   pipeline GitHub Actions et le déploiement Scaleway.
 
-#### Phase 1: Analyse Concurrente (PM + Test Designer)
-**Durée**: ~30 min | **Parallélisation**: PM et Test Designer travaillent simultanément
-
-**Product Manager (Rôle: Extraction de Valeur)**
-- Analyse issue GitHub avec template structuré
-- Extraction valeur métier claire et actionnable
-- Validation exigences avec dev-utilisateur
-- Production: Spécification fonctionnelle validée
-
-**Test Designer (Rôle: Planification Technique)**
-- Analyse technique parallèle de l'issue
-- Estimation nombre features/refactors uniques
-- Planification PRs et worktrees nécessaires
-- Production: Plan d'implémentation détaillé
-
-#### Phase 2: Fondation Tests (Test Designer)
-**Durée**: ~45 min | **Focus**: Environnement + Spécifications Test
-
-**Préparation Environnement**
-```bash
-# Création worktree optimisée avec template
-git worktree add ../feature-name feature/branch-name
-cd ../feature-name
-ln -s ../velib-mcp/CLAUDE.md CLAUDE.md
-cargo test --no-run  # Pré-compilation dependencies
-```
-
-**Implémentation Tests TDD**
-- Tests d'intégration définissant comportement attendu
-- Tests unitaires pour composants critiques
-- Tests fuzz si applicable (données externes)
-- Validation: Tests échouent de manière attendue
-
-#### Phase 3: Sprint Implémentation (Ingénieur)
-**Durée**: Variable | **Focus**: Développement avec Validation Continue
-
-**Workflow Micro-Commits**
-```bash
-# Cycle développement optimisé
-while [[ $tests_failing ]]; do
-    # Implémentation incrémentale
-    cargo clippy --fix
-    cargo fmt
-    cargo test
-    git add -A && git commit -m "feat: micro-increment"
-done
-```
-
-**Intégration Continue Locale**
-- Validation automatique à chaque commit
-- Feedback temps réel des tests
-- Métriques qualité code continues
-- Résolution bloquants technique immédiate
-
-#### Phase 4: Révision Parallèle (Ingénieur + Réviseur)
-**Durée**: ~20 min | **Parallélisation**: Préparation + Analyse simultanées
-
-**Ingénieur (Préparation PR)**
-- Organisation commits en histoire cohérente
-- Rédaction description PR succincte
-- Validation finale checks locaux
-- Ouverture PR avec lien issue origine
-
-**Réviseur Senior (Analyse Qualité)**
-- Évaluation architecture et patterns Rust
-- Vérification couverture tests vs objectifs PM
-- Analyse lisibilité et extensibilité code
-- Validation sécurité et ergonomie
-
-**Boucle Feedback Structurée**
-- Critères évaluation standardisés
-- Dialogue constructif jusqu'accord
-- Résolution collaborative des points bloquants
-
-#### Phase 5: Intégration Automatisée (Ops)
-**Durée**: ~10 min | **Focus**: Déploiement et Validation
-
-**Merge et CI/CD**
-- Merge automatique post-approbation
-- Validation CI complète sur main
-- Monitoring santé déploiement
-- Métriques performance production
-
-### Templates et Checklists
-
-#### Template Analyse Issue (PM)
-```markdown
-## Valeur Métier
-- [ ] Problème utilisateur identifié
-- [ ] Solution proposée claire
-- [ ] Critères succès mesurables
-- [ ] Validation dev-utilisateur
-
-## Exigences Techniques
-- [ ] Contraintes techniques identifiées
-- [ ] Impact architecture évalué
-- [ ] Effort estimé (S/M/L/XL)
-```
-
-#### Checklist Qualité (Réviseur)
-```markdown
-## Architecture & Design
-- [ ] Patterns Rust idiomatiques respectés
-- [ ] Séparation responsabilités claire
-- [ ] Gestion erreurs appropriée
-- [ ] Performance optimisée
-
-## Tests & Couverture
-- [ ] Tests couvrent objectifs PM
-- [ ] Edge cases identifiés et testés
-- [ ] Intégration validée
-- [ ] Documentation à jour
-```
-
-### Intégration Architecture Existante
-
-Ce processus s'intègre parfaitement avec:
-- Architecture worktree existante (isolation parallèle)
-- CI/CD GitHub Actions (validation automatisée)
-- Hooks pre-commit (qualité continue)
-- Toolchain Rust standard (fmt, clippy, audit)
+### Checklist Qualité (Revue)
+- Patterns Rust idiomatiques et séparation des responsabilités
+- Gestion d'erreur explicite (pas de `unwrap` en chemin chaud)
+- Couverture des cas limites
+- Documentation mise à jour si l'API publique change
+- Validations sécurité (ex. zone de service 50 km) préservées

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A high-performance Model Context Protocol (MCP) server providing access to Paris
 Install and use the Velib MCP server with Claude Code in one command:
 
 ```bash
-# Install and configure the server (port is read from the PORT env var; default 8080)
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
+# Install and configure the server (PORT env var overrides the default 8080)
+cargo install --git https://github.com/DominicBurkart/velib-mcp.git
 claude config add-server velib-mcp "PORT=3000 velib-mcp"
 ```
 
@@ -50,20 +50,18 @@ This project exposes two key Parisian datasets through MCP:
 <details>
 <summary>Click to expand integration guides</summary>
 
-### ChatGPT
+All integrations share the same install step:
+
 ```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server (defaults to 0.0.0.0:8080; set PORT/IP to override)
-velib-mcp
-# Configure in ChatGPT Custom Instructions or use via API
+cargo install --git https://github.com/DominicBurkart/velib-mcp.git
 ```
 
+The server binds `0.0.0.0:8080` by default; set `PORT`/`IP` env vars to override.
+
+### ChatGPT
+Run `velib-mcp` and configure via ChatGPT Custom Instructions or the API.
+
 ### Cursor
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-```
 Add to Cursor's `settings.json`:
 ```json
 {
@@ -77,19 +75,10 @@ Add to Cursor's `settings.json`:
 ```
 
 ### Le Chat / Mistral
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Run server and use via API calls (PORT/IP env vars configure the bind address)
-PORT=8080 velib-mcp
-```
+Run `PORT=8080 velib-mcp` and call via the API.
 
 ### Windsurf
-```bash
-# Install server
-cargo install --git https://github.com/dominicburkart/velib-mcp.git
-# Configure in Windsurf MCP settings
-```
+Configure `velib-mcp` in Windsurf MCP settings.
 
 </details>
 
@@ -104,7 +93,7 @@ cargo install --git https://github.com/dominicburkart/velib-mcp.git
 ### Setup
 
 ```bash
-git clone https://github.com/dominicburkart/velib-mcp.git
+git clone https://github.com/DominicBurkart/velib-mcp.git
 cd velib-mcp
 cargo build
 ```

--- a/docs/context/etat_actuel.md
+++ b/docs/context/etat_actuel.md
@@ -20,14 +20,14 @@ couverture de tests unitaires et d'intégration automatisée.
 
 ## Interfaces livrées
 
-- Tools MCP : [`find_nearby_stations`](../../src/mcp/handlers.rs),
-  `get_station_by_code`, `search_stations_by_name`,
-  `get_area_statistics`, `plan_bike_journey`.
+- Tools MCP (implémentés dans `src/mcp/handlers.rs`) :
+  `find_nearby_stations`, `get_station_by_code`,
+  `search_stations_by_name`, `get_area_statistics`, `plan_bike_journey`.
 - Resources MCP : `velib://stations/reference`,
   `velib://stations/realtime`, `velib://stations/complete`,
   `velib://health`.
-- Transports : HTTP POST `/mcp` et WebSocket `/mcp/ws`
-  (voir [`src/mcp/server.rs`](../../src/mcp/server.rs)).
+- Transports (voir `src/mcp/server.rs`) : HTTP POST `/mcp` et WebSocket
+  `/mcp/ws`.
 
 ## Évolutions en cours
 

--- a/docs/development/project_prompt.md
+++ b/docs/development/project_prompt.md
@@ -1,5 +1,0 @@
-# Projet Claude Code : Serveur MCP Velib
-
-Ce document a été consolidé dans [`CLAUDE.md`](../../CLAUDE.md) à la racine du
-dépôt. Reportez-vous à ce fichier pour le contexte du projet, les objectifs,
-et le processus de développement.


### PR DESCRIPTION
## Summary

Focused clarity pass across documentation. Scope is limited to docs, comments, and format consistency - no logic changes.

### Change categories

- **CLAUDE.md slimmed (-174 lines)**
  - Removed stale `~/code/velib-mcp/velib-mcp/` worktree paths and ASCII tree that no longer matches the repo layout.
  - Removed checkmark emoji from headings (non-standard for this codebase).
  - Replaced the heavy "Processus de Developpement Multi-Agents" section, which included an auto-commit `while [[ $tests_failing ]]; do ... git commit ...; done` anti-pattern, with a concise 5-step development flow.
  - Stopped duplicating the phase tracker that already lives in `docs/context/etat_actuel.md`; CLAUDE.md now links to it.
  - Kept all unique guidance (toolchain, deploy targets, worktree symlink convention, quality checklist).

- **README.md deduplication**
  - Collapsed four near-identical `cargo install --git ...` snippets in the integration section into one shared block plus per-tool config notes.
  - Normalized GitHub URLs to `DominicBurkart` casing (the badges already use this form; the install/clone commands used `dominicburkart`).
  - Trimmed redundant inline `# Install server` / `# Run server` comments.

- **docs/context/etat_actuel.md format consistency**
  - Removed relative markdown links from docs into `src/*.rs` files (non-standard for documentation, brittle to refactors); replaced with prose references to the same source files.

- **Removed `docs/development/project_prompt.md`**
  - Five-line redirect stub with no inbound links anywhere in the repo.

## Test plan

- [ ] Visual review of rendered Markdown on GitHub
- [ ] `grep -r "code/velib-mcp" .` returns nothing
- [ ] `grep -r "dominicburkart/velib-mcp" .` returns nothing (URLs canonical-cased)
- [ ] CI passes (no code changed, but confirming docs-only PR is green)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb)_