### PR TITLE
arch: drop dead RetryStrategy::FixedDelay variant

### DIFF
--- a/src/data/retry.rs
+++ b/src/data/retry.rs
@@ -80,7 +80,11 @@ impl Default for RetryConfig {
     }
 }
 
-/// Strategy for calculating retry delays
+/// Strategy for calculating retry delays.
+///
+/// Currently only exponential backoff is exercised by the codebase. The enum
+/// shape is retained as a single-variant extension point: future strategies
+/// (e.g. decorrelated jitter) can be added here without churning call sites.
 #[derive(Debug, Clone)]
 pub enum RetryStrategy {
     /// Exponential backoff with optional jitter
@@ -91,11 +95,6 @@ pub enum RetryStrategy {
         max_delay: u64,
         /// Whether to add jitter (up to 25% of calculated delay)
         use_jitter: bool,
-    },
-    /// Fixed delay between retries
-    FixedDelay {
-        /// Delay in seconds
-        delay: u64,
     },
 }
 
@@ -120,7 +119,6 @@ impl RetryStrategy {
                     Duration::from_secs(delay)
                 }
             }
-            RetryStrategy::FixedDelay { delay } => Duration::from_secs(*delay),
         }
     }
 }
@@ -360,15 +358,6 @@ mod tests {
         assert_eq!(strategy.calculate_delay(2), Duration::from_secs(4));
         assert_eq!(strategy.calculate_delay(3), Duration::from_secs(8));
         assert_eq!(strategy.calculate_delay(4), Duration::from_secs(10)); // Capped at max_delay
-    }
-
-    #[test]
-    fn test_fixed_delay_calculation() {
-        let strategy = RetryStrategy::FixedDelay { delay: 5 };
-
-        assert_eq!(strategy.calculate_delay(0), Duration::from_secs(5));
-        assert_eq!(strategy.calculate_delay(1), Duration::from_secs(5));
-        assert_eq!(strategy.calculate_delay(2), Duration::from_secs(5));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`RetryStrategy::FixedDelay` is never constructed anywhere in `src/` (only its own unit test instantiates it). `RetryPolicy::with_config` builds `ExponentialBackoff` unconditionally, so the second variant is unreachable. This PR removes the dead variant and its dedicated test.

## Concrete reduction

- `src/data/retry.rs`: -16 LOC (variant body 5 lines, match arm 1 line, dedicated `test_fixed_delay_calculation` 7 lines, plus comment churn).
- One less public enum branch on the data-client API surface.

## Justification (per CLAUDE.md "Patterns Rust idiomatiques" / "Performance optimisée")

- Unused enum variants are dead code that misrepresents the public API as offering a "fixed delay" strategy the rest of the codebase cannot opt into.
- Retaining `RetryStrategy` as a single-variant enum keeps the door open for future strategies (e.g. decorrelated jitter) without churning call sites.

## Test plan

- [x] `cargo build` succeeds.
- [x] `cargo test --lib` 83/83 pass locally (unit tests).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] No external caller references `FixedDelay` (verified by grep across `src/` and `tests/`).
- [ ] CI to confirm full integration suite.

## Risk

Low. Variant was never constructed in production code or any integration test on `main`.

https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb)_