### PR TITLE
clarity: standardize doc timestamps and remove version drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,14 +38,7 @@ Créer un serveur cloud MCP performant pour rendre accessibles aux assistants IA
 
 ## État Actuel du Projet
 
-### Phases Terminées ✅
-- **Phase 0** : Configuration projet, CI/CD, structure documentation
-- **Phase 1** : Analyse complète des données Velib (15+ champs documentés)
-- **Phase 2A** : Configuration environnement et fondation serveur de base
-- **Phase 2B** : Fondation protocole MCP et types de base
-- **Phase 3A** : Intégration API live et client de données
-- **Phase 3B** : Handlers MCP complets avec intégration données live
-- **Phase 4** : Nettoyage structure repository (suppression worktrees committés)
+Pour le statut détaillé par phase, voir [`docs/context/etat_actuel.md`](docs/context/etat_actuel.md).
 
 ### Architecture Technique
 - **Serveur MCP Rust** pour données Velib Paris

--- a/docs/api/data_analysis.md
+++ b/docs/api/data_analysis.md
@@ -49,8 +49,8 @@ https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-
 #### Données Temporelles
 | Champ | Type | Format | Exemple |
 |-------|------|--------|---------|
-| `duedate` | string | ISO 8601 | "2025-06-14T19:31:22+00:00" |
-| `record_timestamp` | string | ISO 8601 | "2025-06-14T19:31:22+00:00" |
+| `duedate` | string | ISO 8601 | "2026-04-23T19:31:22+00:00" |
+| `record_timestamp` | string | ISO 8601 | "2026-04-23T19:31:22+00:00" |
 
 #### Informations Administratives
 | Champ | Type | Description |

--- a/docs/api/mcp_interface_spec.md
+++ b/docs/api/mcp_interface_spec.md
@@ -8,7 +8,7 @@ Ce document définit les interfaces MCP (Model Context Protocol) exposées par l
 
 ### Serveur MCP
 - **Nom** : `velib-mcp`
-- **Version** : `1.0.0`
+- **Version** : voir [`Cargo.toml`](../../Cargo.toml)
 - **Description** : Serveur MCP pour les données Velib Paris
 - **Capacités** : `resources`, `tools`
 
@@ -51,7 +51,7 @@ application/json
   ],
   "metadata": {
     "total_stations": 1400,
-    "last_updated": "2025-06-14T06:00:00Z"
+    "last_updated": "2026-04-23T06:00:00Z"
   }
 }
 ```
@@ -88,12 +88,12 @@ application/json
         "installed": true
       },
       "status": "Operational",
-      "last_updated": "2025-06-14T19:31:22Z"
+      "last_updated": "2026-04-23T19:31:22Z"
     }
   ],
   "metadata": {
     "data_freshness": "Fresh",
-    "response_time": "2025-06-14T19:31:25Z"
+    "response_time": "2026-04-23T19:31:25Z"
   }
 }
 ```
@@ -503,7 +503,7 @@ Planifie un trajet en suggérant stations de départ et d'arrivée.
 ```
 X-RateLimit-Limit: 100
 X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1640995200
+X-RateLimit-Reset: 1776067200
 ```
 
 ## Authentification
@@ -528,17 +528,17 @@ velib://health
 ```json
 {
   "status": "healthy",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "uptime_seconds": 86400,
   "data_sources": {
     "real_time": {
       "status": "healthy",
-      "last_update": "2025-06-14T19:31:22Z",
+      "last_update": "2026-04-23T19:31:22Z",
       "lag_seconds": 45
     },
     "reference": {
-      "status": "healthy", 
-      "last_update": "2025-06-14T06:00:00Z"
+      "status": "healthy",
+      "last_update": "2026-04-23T06:00:00Z"
     }
   },
   "cache_stats": {

--- a/docs/api/mcp_schemas.md
+++ b/docs/api/mcp_schemas.md
@@ -353,8 +353,8 @@ pub enum ValidationError {
       "installed": true
     },
     "status": "Operational",
-    "last_updated": "2025-06-14T19:31:22Z",
-    "valid_until": "2025-06-14T19:33:22Z"
+    "last_updated": "2026-04-23T19:31:22Z",
+    "valid_until": "2026-04-23T19:33:22Z"
   },
   "data_freshness": "Fresh"
 }


### PR DESCRIPTION
## Summary

Pure standardization pass on the docs. No information removed; only stale formats and duplicated content cleaned up.

### Standardizations applied

- **Example timestamps**: `docs/api/{mcp_interface_spec,mcp_schemas,data_analysis}.md` all used hard-coded `2025-06-14` ISO timestamps in JSON examples. Refreshed to `2026-04-23` so readers do not mistake the examples for live data and so the date matches the `etat_actuel.md` "last updated" anchor.
- **Version literal**: `mcp_interface_spec.md` declared the server version as `1.0.0` while `Cargo.toml` says `0.1.0`. The "Architecture MCP" block now points to `Cargo.toml` as the single source of truth; the health-resource example uses the actual `0.1.0`.
- **Stale epoch in example**: the `X-RateLimit-Reset` header example used `1640995200` (Jan 2022). Replaced with a forward-dated example so reviewers do not misread it as a real value.
- **Duplicated phase list**: `CLAUDE.md` duplicated the "Phases Terminées" table that already lives in `docs/context/etat_actuel.md`. Replaced the duplicated bullets with a pointer; `etat_actuel.md` remains the canonical source.

### Issues found but left for follow-ups (out of scope here)

- `docs/api/mcp_schemas.md` describes types that have diverged from `src/types.rs` (`StationStatus` variants, `RealTimeStatus.valid_until`/`station_code` fields, `BikeTypeFilter` having 4 variants instead of 3, `VelibStation.data_freshness`). Realigning the schema doc with the implementation is a structural change better suited to an arch PR than a clarity PR.

## Test plan

- [ ] CI green (docs-only change; no code touched)
- [ ] Spot-check rendered markdown for the four modified files

---
_Generated by [Claude Code](https://claude.ai/code/session_01173Smn5AbVSYT2cT3QKuNN)_