### PR TITLE
fix(mcp): source health endpoint version from Cargo.toml

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -553,7 +553,7 @@ async fn get_health_resource(handler: Arc<McpToolHandler>, start_time: Instant) 
 
     Ok(json!({
         "status": "healthy",
-        "version": "1.0.0",
+        "version": env!("CARGO_PKG_VERSION"),
         "uptime_seconds": uptime_seconds,
         "data_sources": {
             "real_time": {


### PR DESCRIPTION
## What changed

The `velib://health` resource handler hard-coded `"version": "1.0.0"`
while the crate version in `Cargo.toml` is `0.1.0`. This PR replaces the
string literal with `env!("CARGO_PKG_VERSION")` so the reported version
is always sourced from the package manifest at compile time.

```diff
-        "version": "1.0.0",
+        "version": env!("CARGO_PKG_VERSION"),
```

## Why this preserves functionality

- `env!("CARGO_PKG_VERSION")` is resolved by Cargo at compile time to a
  `&'static str` literal, so the JSON payload shape is unchanged: the
  `version` field remains a string.
- No tests pin the literal value `"1.0.0"` (verified by `rg "1\.0\.0"
  src/ tests/`), so existing assertions on the health endpoint continue
  to pass.
- The only externally observable change is that the value now matches
  the shipped binary's actual version. The previous `1.0.0` was a
  fabrication that disagreed with the manifest.
- Once Cargo.toml is bumped, the health endpoint will track it
  automatically; the two can no longer drift apart.

## Verification

- `cargo check --all-targets` -- builds clean.
- `cargo fmt --check` -- no diff.
- `cargo clippy --all-targets -- -D warnings` -- no warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01173Smn5AbVSYT2cT3QKuNN)_