### PR TITLE
chore: maintenance pass (architecture, tests, docs)

### DIFF
--- a/docs/api/mcp_interface_spec.md
+++ b/docs/api/mcp_interface_spec.md
@@ -298,7 +298,7 @@ Recherche textuelle dans les noms de stations.
     "limit": {
       "type": "integer",
       "minimum": 1,
-      "maximum": 50,
+      "maximum": 100,
       "default": 10,
       "description": "Nombre maximum de résultats"
     },
@@ -453,11 +453,11 @@ Planifie un trajet en suggérant stations de départ et d'arrivée.
             "properties": {
               "pickup_station": {"$ref": "#/definitions/VelibStation"},
               "dropoff_station": {"$ref": "#/definitions/VelibStation"},
-              "walk_to_pickup": {"type": "integer"},
-              "walk_from_dropoff": {"type": "integer"},
+              "straight_line_to_pickup_meters": {"type": "integer"},
+              "straight_line_from_dropoff_meters": {"type": "integer"},
               "confidence_score": {
                 "type": "number",
-                "minimum": 0,
+                "minimum": 0.1,
                 "maximum": 1
               }
             }
@@ -471,51 +471,55 @@ Planifie un trajet en suggérant stations de départ et d'arrivée.
 
 ## Gestion des Erreurs
 
-### Codes d'Erreur Standard
+### Format JSON-RPC
+
+Toute erreur est renvoyée dans le champ `error` d'une réponse JSON-RPC
+2.0. Le champ `data.error_type` est une chaîne stable utilisable par les
+clients pour discriminer les variantes sans parser le message.
+
 ```json
 {
   "error": {
-    "code": -32001,
-    "message": "Station not found",
+    "code": -32600,
+    "message": "Station not found: 99999",
     "data": {
-      "station_code": "99999",
-      "error_type": "STATION_NOT_FOUND"
+      "error_type": "station_not_found"
     }
   }
 }
 ```
 
-### Types d'Erreurs
-- `-32001` : Station non trouvée
-- `-32002` : Coordonnées invalides  
-- `-32003` : Données temps réel indisponibles
-- `-32004` : Rayon de recherche trop large
-- `-32005` : Limite de résultats dépassée
+### Mapping codes / `error_type`
+
+La source de vérité est [`src/error.rs`](../../src/error.rs)
+(`Error::mcp_error_code` et `Error::error_type`).
+
+| Code     | `error_type`              | Variante Rust                |
+|----------|---------------------------|------------------------------|
+| `-32700` | `json_error`              | `Error::Json`                |
+| `-32600` | `station_not_found`       | `Error::StationNotFound`     |
+| `-32602` | `invalid_coordinates`     | `Error::InvalidCoordinates`  |
+| `-32602` | `outside_service_area`    | `Error::OutsideServiceArea`  |
+| `-32602` | `search_radius_too_large` | `Error::SearchRadiusTooLarge`|
+| `-32602` | `result_limit_exceeded`   | `Error::ResultLimitExceeded` |
+| `-32602` | `validation_error`        | `Error::Validation`          |
+| `-32603` | `mcp_protocol_error`      | `Error::McpProtocol`         |
+| `-32603` | `cache_error`             | `Error::Cache`               |
+| `-32603` | `internal_error`          | `Error::Internal`            |
+| `-32001` | `http_error`              | `Error::Http`                |
+| `-32001` | `rate_limited`            | `Error::RateLimited`         |
 
 ## Rate Limiting
 
-### Limites par Défaut
-- **Resources** : 60 requêtes/minute
-- **Tools** : 100 requêtes/minute
-- **Burst** : 10 requêtes/seconde
-
-### Headers de Réponse
-```
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1640995200
-```
+Pas de rate limiting applicatif côté serveur à ce jour. Les retries vers
+l'API Paris Open Data utilisent un backoff exponentiel
+(`Error::RateLimited` + `Retry-After`); voir
+[`src/data/retry.rs`](../../src/data/retry.rs).
 
 ## Authentification
 
-### Mode Public
-- Aucune authentification requise
-- Rate limiting appliqué par IP
-
-### Mode API Key (Futur)
-```http
-Authorization: Bearer <api_key>
-```
+Aucune authentification requise; le serveur expose les données Velib
+publiques telles quelles.
 
 ## Métadonnées de Santé
 
@@ -525,6 +529,13 @@ velib://health
 ```
 
 #### Contenu
+La réponse est produite par
+[`get_health_resource`](../../src/mcp/server.rs). `cache_stats` reflète
+la taille réelle des caches; `hit_rate` est volontairement omis (le cache
+ne suit pas hits/misses, voir
+[`src/data/cache.rs`](../../src/data/cache.rs)). `lag_seconds` est calculé
+à partir du `last_update` le plus récent observé dans les données live.
+
 ```json
 {
   "status": "healthy",
@@ -533,17 +544,18 @@ velib://health
   "data_sources": {
     "real_time": {
       "status": "healthy",
-      "last_update": "2025-06-14T19:31:22Z",
+      "last_update": "2026-04-23T19:31:22Z",
       "lag_seconds": 45
     },
     "reference": {
-      "status": "healthy", 
-      "last_update": "2025-06-14T06:00:00Z"
+      "status": "healthy",
+      "last_update": "2026-04-23T19:31:22Z"
     }
   },
   "cache_stats": {
-    "hit_rate": 0.85,
-    "entries": 1400
+    "entries": 2,
+    "reference_cache_size": 1,
+    "realtime_cache_size": 1
   }
 }
 ```

--- a/docs/api/mcp_schemas.md
+++ b/docs/api/mcp_schemas.md
@@ -1,361 +1,96 @@
 # Schémas de Données MCP - Velib Server
 
-## Vue d'ensemble
+## Source de vérité
 
-Ce document définit les schémas de données formels pour l'exposition des données Velib via le protocole MCP (Model Context Protocol).
+Les types Rust sont la source de vérité; ce document décrit la forme
+canonique sérialisée. Les fichiers à consulter en cas de divergence:
 
-## Types de Base
+- Types de domaine: [`src/types.rs`](../../src/types.rs)
+  (`Coordinates`, `StationStatus`, `ServiceCapabilities`,
+  `BikeAvailability`, `DataFreshness`, `BikeTypeFilter`,
+  `StationReference`, `RealTimeStatus`, `VelibStation`).
+- Types d'entrée/sortie MCP:
+  [`src/mcp/types.rs`](../../src/mcp/types.rs)
+  (`AvailabilityFilter`, `GeographicBounds`, `StationWithDistance`,
+  `JourneyRecommendation`, `BikeJourney`, `AreaStatistics`, et les
+  variantes `*Input` / `*Output` de chaque tool).
+- Erreurs: [`src/error.rs`](../../src/error.rs) (`Error`,
+  `mcp_error_code`, `error_type`).
 
-### Coordonnées Géographiques
-```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct Coordinates {
-    /// Latitude en degrés décimaux
-    pub latitude: f64,
-    /// Longitude en degrés décimaux  
-    pub longitude: f64,
-}
-```
+## Conventions
 
-### État de Station
-```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum StationStatus {
-    /// Station opérationnelle
-    Operational,
-    /// Station installée mais non opérationnelle
-    Installed,
-    /// Station en maintenance
-    Maintenance,
-    /// Station hors service
-    OutOfService,
-}
-```
+- Sérialisation: JSON UTF-8 via `serde_json`.
+- Enums avec `#[serde(rename = "...")]` explicitement listés
+  ci-dessous; les autres utilisent la variante PascalCase.
+- Tous les champs `Option<T>` portent
+  `#[serde(skip_serializing_if = "Option::is_none")]` — le JSON ne
+  contient pas le champ quand il est absent.
 
-### Capacités de Service
-```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct ServiceCapabilities {
-    /// Location de vélos autorisée
-    pub renting_enabled: bool,
-    /// Retour de vélos autorisé
-    pub returning_enabled: bool,
-    /// Station installée et accessible
-    pub installed: bool,
-}
-```
+### Renommages serde notables
 
-## Schémas Principaux
+| Type            | Variante Rust       | JSON          |
+|-----------------|---------------------|---------------|
+| `StationStatus` | `Open`              | `"OPEN"`      |
+| `StationStatus` | `Closed`            | `"CLOSED"`    |
+| `StationStatus` | `Maintenance`       | `"MAINTENANCE"` |
+| `BikeTypeFilter`| `MechanicalOnly`    | `"mechanical"`|
+| `BikeTypeFilter`| `ElectricOnly`      | `"electric"`  |
+| `BikeTypeFilter`| `AnyType`           | `"any"`       |
 
-### Station de Référence
-```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct StationReference {
-    /// Identifiant unique de la station
-    pub station_code: String,
-    
-    /// Nom descriptif de la station
-    pub name: String,
-    
-    /// Coordonnées géographiques précises
-    pub coordinates: Coordinates,
-    
-    /// Capacité totale de la station
-    pub capacity: u16,
-    
-    /// Commune ou arrondissement
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub commune: Option<String>,
-    
-    /// Code INSEE de la commune
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub insee_code: Option<String>,
-}
-```
+`DataFreshness` (Fresh/Recent/Stale/VeryStale) sérialise avec les noms
+PascalCase par défaut.
 
-### Disponibilité Temps Réel
-```rust
-use chrono::{DateTime, Utc};
+## Exemple de Station Complète
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct BikeAvailability {
-    /// Vélos mécaniques disponibles
-    pub mechanical: u16,
-    
-    /// Vélos électriques disponibles
-    pub electric: u16,
-}
+`VelibStation` n'utilise pas `#[serde(flatten)]`: les données de
+référence vivent sous `reference`, les données temps réel sous
+`real_time` quand elles sont disponibles.
 
-impl BikeAvailability {
-    /// Total de vélos disponibles
-    pub fn total(&self) -> u16 {
-        self.mechanical + self.electric
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct RealTimeStatus {
-    /// Référence à la station
-    pub station_code: String,
-    
-    /// Vélos disponibles par type
-    pub bikes: BikeAvailability,
-    
-    /// Emplacements libres pour retour
-    pub available_docks: u16,
-    
-    /// Capacités de service actuelles
-    pub service: ServiceCapabilities,
-    
-    /// État général de la station
-    pub status: StationStatus,
-    
-    /// Horodatage de dernière mise à jour
-    pub last_updated: DateTime<Utc>,
-    
-    /// Horodatage de validité des données
-    pub valid_until: DateTime<Utc>,
-}
-```
-
-### Station Complète (Vue Consolidée)
-```rust
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct VelibStation {
-    /// Données de référence de la station
-    #[serde(flatten)]
-    pub reference: StationReference,
-    
-    /// État temps réel actuel
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub real_time: Option<RealTimeStatus>,
-    
-    /// Indicateur de fraîcheur des données
-    pub data_freshness: DataFreshness,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum DataFreshness {
-    /// Données très récentes (< 2 minutes)
-    Fresh,
-    /// Données acceptables (< 5 minutes)
-    Acceptable,
-    /// Données anciennes (> 5 minutes)
-    Stale,
-    /// Données indisponibles
-    Unavailable,
-}
-```
-
-## Schémas de Requête MCP
-
-### Paramètres de Recherche Géographique
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct GeographicQuery {
-    /// Point central de recherche
-    pub center: Coordinates,
-    
-    /// Rayon de recherche en mètres
-    pub radius_meters: u32,
-    
-    /// Nombre maximum de résultats
-    #[serde(default = "default_limit")]
-    pub limit: u16,
-}
-
-fn default_limit() -> u16 { 50 }
-```
-
-### Filtres de Disponibilité
-```rust
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct AvailabilityFilter {
-    /// Minimum de vélos disponibles requis
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_bikes: Option<u16>,
-    
-    /// Minimum d'emplacements libres requis
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_docks: Option<u16>,
-    
-    /// Type de vélos requis
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bike_type: Option<BikeTypeFilter>,
-    
-    /// Exclure les stations hors service
-    #[serde(default = "default_true")]
-    pub exclude_out_of_service: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum BikeTypeFilter {
-    /// Au moins un vélo mécanique
-    MechanicalRequired,
-    /// Au moins un vélo électrique
-    ElectricRequired,
-    /// Vélos mécaniques ET électriques
-    BothRequired,
-    /// Vélos mécaniques OU électriques
-    AnyType,
-}
-
-fn default_true() -> bool { true }
-```
-
-### Requête Complète
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct StationQuery {
-    /// Contraintes géographiques
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub geographic: Option<GeographicQuery>,
-    
-    /// Filtres de disponibilité
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub availability: Option<AvailabilityFilter>,
-    
-    /// Codes de stations spécifiques
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub station_codes: Option<Vec<String>>,
-    
-    /// Inclure les données temps réel
-    #[serde(default = "default_true")]
-    pub include_real_time: bool,
-}
-```
-
-## Schémas de Réponse MCP
-
-### Réponse de Liste de Stations
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct StationListResponse {
-    /// Stations correspondant aux critères
-    pub stations: Vec<VelibStation>,
-    
-    /// Nombre total de stations trouvées
-    pub total_count: usize,
-    
-    /// Pagination si applicable
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pagination: Option<PaginationInfo>,
-    
-    /// Métadonnées de la requête
-    pub metadata: ResponseMetadata,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct PaginationInfo {
-    pub offset: usize,
-    pub limit: usize,
-    pub has_more: bool,
-}
-```
-
-### Métadonnées de Réponse
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ResponseMetadata {
-    /// Horodatage de la réponse
-    pub response_time: DateTime<Utc>,
-    
-    /// Durée de traitement en millisecondes
-    pub processing_time_ms: u64,
-    
-    /// Source des données temps réel
-    pub real_time_source: DataSource,
-    
-    /// Source des données de référence
-    pub reference_source: DataSource,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum DataSource {
-    /// Données fraîches de l'API
-    Live,
-    /// Données du cache local
-    Cached { age_seconds: u64 },
-    /// Données de sauvegarde
-    Fallback,
-    /// Données indisponibles
-    Unavailable,
-}
-```
-
-## Validation et Contraintes
-
-### Contraintes de Cohérence
-```rust
-impl VelibStation {
-    /// Valide la cohérence des données de la station
-    pub fn validate(&self) -> Result<(), ValidationError> {
-        // Vérifier la cohérence des compteurs
-        if let Some(rt) = &self.real_time {
-            let total_bikes = rt.bikes.total();
-            let expected_docks = self.reference.capacity
-                .checked_sub(total_bikes)
-                .ok_or(ValidationError::CapacityOverflow)?;
-                
-            if rt.available_docks != expected_docks {
-                return Err(ValidationError::DockCountMismatch);
-            }
-        }
-        
-        // Validation des coordonnées (Paris métropole)
-        let coords = &self.reference.coordinates;
-        if coords.latitude < 48.7 || coords.latitude > 49.0 ||
-           coords.longitude < 2.0 || coords.longitude > 2.6 {
-            return Err(ValidationError::InvalidCoordinates);
-        }
-        
-        Ok(())
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ValidationError {
-    #[error("La capacité de la station est dépassée")]
-    CapacityOverflow,
-    
-    #[error("Incohérence entre vélos et emplacements disponibles")]
-    DockCountMismatch,
-    
-    #[error("Coordonnées hors de la zone de service")]
-    InvalidCoordinates,
-}
-```
-
-## Sérialisation JSON
-
-### Exemple de Station Complète
 ```json
 {
-  "station_code": "32017",
-  "name": "Rouget de L'isle - Watteau",
-  "coordinates": {
-    "latitude": 48.936268,
-    "longitude": 2.358866
-  },
-  "capacity": 22,
-  "commune": "Issy-les-Moulineaux",
-  "insee_code": "92040",
-  "real_time": {
+  "reference": {
     "station_code": "32017",
+    "name": "Rouget de L'isle - Watteau",
+    "coordinates": {
+      "latitude": 48.936268,
+      "longitude": 2.358866
+    },
+    "capacity": 22,
+    "capabilities": {
+      "accepts_credit_card": false,
+      "has_charging_station": false,
+      "is_virtual_station": false
+    }
+  },
+  "real_time": {
     "bikes": {
       "mechanical": 8,
       "electric": 4
     },
     "available_docks": 10,
-    "service": {
-      "renting_enabled": true,
-      "returning_enabled": true,
-      "installed": true
-    },
-    "status": "Operational",
-    "last_updated": "2025-06-14T19:31:22Z",
-    "valid_until": "2025-06-14T19:33:22Z"
-  },
-  "data_freshness": "Fresh"
+    "status": "OPEN",
+    "last_update": "2026-04-23T19:31:22Z",
+    "data_freshness": "Fresh"
+  }
 }
 ```
+
+Les champs `nom_arrondissement_communes` / `code_insee_commune` du
+dataset Paris Open Data ne sont pas exposés par l'API MCP actuelle.
+
+## Validation
+
+`StationReference::validate` et `VelibStation::validate` renvoient une
+`Result<(), String>` et appliquent:
+
+- `station_code` non vide;
+- `name` non vide;
+- `capacity` strictement positive et `<= 200`;
+- coordonnées dans le bounding box Paris métropole
+  (`is_valid_paris_metro`, ~250 km autour de Paris);
+- bikes + docks `<= capacity` (overflow physique de la station).
+
+La validation des entrées des tools (rayon max, limite max, zone de
+service 50 km autour de Paris) vit dans
+[`src/mcp/handlers.rs`](../../src/mcp/handlers.rs) — voir
+`ensure_in_service_area`, `MAX_SEARCH_RADIUS`, `MAX_RESULT_LIMIT`.

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -16,6 +16,31 @@ use tokio::sync::RwLock;
 
 const MAX_SEARCH_RADIUS: u32 = 5000; // 5km
 const MAX_RESULT_LIMIT: u16 = 100;
+const MIN_SEARCH_QUERY_LEN: usize = 2;
+
+/// Normalize a string for case- and accent-insensitive name matching.
+///
+/// Lower-cases the input then applies Unicode NFC normalization so that
+/// pre-composed and decomposed forms of the same accented character compare
+/// equal. Used by `search_stations_by_name` for both the query and each
+/// candidate station name.
+fn normalize_for_search(s: &str) -> String {
+    s.to_lowercase().nfc().collect()
+}
+
+/// Test whether `name` matches `query` under the given fuzzy/prefix mode.
+///
+/// Both inputs are expected to already be normalized via
+/// `normalize_for_search`. Extracted as a pure function so the matching rule
+/// (prefix vs. contains) can be unit-tested without going through the full
+/// handler + data-client wiring.
+fn name_matches_query(name: &str, query: &str, fuzzy: bool) -> bool {
+    if fuzzy {
+        name.contains(query)
+    } else {
+        name.starts_with(query)
+    }
+}
 
 /// Validate that a coordinate is within the Velib service area, returning the
 /// appropriate `Error` if not. Centralizes the two checks previously duplicated
@@ -262,8 +287,10 @@ impl McpToolHandler {
     ) -> Result<SearchStationsByNameOutput> {
         let start_time = Instant::now();
 
-        if input.query.len() < 2 {
-            return Err(Error::Internal(anyhow::anyhow!("Search query too short")));
+        if input.query.len() < MIN_SEARCH_QUERY_LEN {
+            return Err(Error::Validation(format!(
+                "Search query must be at least {MIN_SEARCH_QUERY_LEN} characters"
+            )));
         }
 
         if input.limit > MAX_RESULT_LIMIT {
@@ -277,21 +304,12 @@ impl McpToolHandler {
         let mut data_client = self.data_client.write().await;
         let all_stations = data_client.get_all_stations(true).await?;
 
-        let query_normalized = input.query.to_lowercase().nfc().collect::<String>();
+        let query_normalized = normalize_for_search(&input.query);
         let mut matching_stations: Vec<VelibStation> = all_stations
             .into_iter()
             .filter(|station| {
-                let name_normalized = station
-                    .reference
-                    .name
-                    .to_lowercase()
-                    .nfc()
-                    .collect::<String>();
-                if input.fuzzy {
-                    name_normalized.contains(&query_normalized)
-                } else {
-                    name_normalized.starts_with(&query_normalized)
-                }
+                let name_normalized = normalize_for_search(&station.reference.name);
+                name_matches_query(&name_normalized, &query_normalized, input.fuzzy)
             })
             .collect();
 
@@ -735,6 +753,63 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_invariants_hold_across_mixed_inputs() {
+        // Document the load-bearing invariants of `aggregate_area_statistics`
+        // and check them against a deliberately varied input set:
+        //   1. available_bikes.total == mechanical + electric (no drift).
+        //   2. operational_stations <= total_stations.
+        //   3. occupancy_rate is finite and >= 0 (an honest ratio).
+        //
+        // Stations: one open, one closed, one maintenance, one with no
+        // real-time data. Capacities are all 20 (see `make_station`).
+        let mut closed = make_station("c", 48.85, 2.35, 1, 0);
+        if let Some(rt) = closed.real_time.as_mut() {
+            rt.status = StationStatus::Closed;
+        }
+        let mut maint = make_station("m", 48.86, 2.36, 0, 1);
+        if let Some(rt) = maint.real_time.as_mut() {
+            rt.status = StationStatus::Maintenance;
+        }
+        let open = make_station("o", 48.87, 2.37, 3, 2);
+        let mut no_rt = make_station("n", 48.88, 2.38, 0, 0);
+        no_rt.real_time = None;
+
+        let stations = vec![closed, maint, open, no_rt];
+        let stats = aggregate_area_statistics(&stations);
+
+        // (1) totals consistency
+        assert_eq!(
+            stats.available_bikes.total,
+            stats.available_bikes.mechanical + stats.available_bikes.electric,
+            "available_bikes.total must equal mechanical + electric"
+        );
+
+        // (2) operational <= total
+        assert!(
+            stats.operational_stations <= stats.total_stations,
+            "operational_stations ({}) must not exceed total_stations ({})",
+            stats.operational_stations,
+            stats.total_stations
+        );
+
+        // (3) occupancy is a non-negative finite number
+        assert!(
+            stats.occupancy_rate.is_finite() && stats.occupancy_rate >= 0.0,
+            "occupancy_rate must be finite and >= 0, got {}",
+            stats.occupancy_rate
+        );
+
+        // Concretely:
+        //   total: 4, operational: 2 (open + no_rt-defaults-to-operational)
+        //   total_capacity: 80 (4 * 20)
+        //   bikes: 1 (closed contributes) + 1 (maint) + 5 (open) + 0 (no_rt) = 7
+        assert_eq!(stats.total_stations, 4);
+        assert_eq!(stats.operational_stations, 2);
+        assert_eq!(stats.total_capacity, 80);
+        assert_eq!(stats.available_bikes.total, 7);
+    }
+
+    #[test]
     fn aggregate_excludes_closed_stations_from_operational_count() {
         let mut closed = make_station("closed", 48.85, 2.35, 5, 0);
         if let Some(rt) = closed.real_time.as_mut() {
@@ -818,5 +893,47 @@ mod tests {
             (journey_confidence_score(0, 0, 0) - 1.0).abs() < 1e-9,
             "(0, 0, 0) should be 1.0"
         );
+    }
+
+    // --- normalize_for_search / name_matches_query ---
+
+    #[test]
+    fn normalize_for_search_lowercases_ascii() {
+        assert_eq!(normalize_for_search("CHATELET"), "chatelet");
+        assert_eq!(normalize_for_search("Châtelet"), "châtelet");
+    }
+
+    #[test]
+    fn normalize_for_search_makes_decomposed_and_composed_forms_match() {
+        // Same visible string in NFD (decomposed) and NFC (precomposed) forms.
+        // After `normalize_for_search` both must yield the same bytes so that
+        // searches across upstream-supplied names are accent-form-agnostic.
+        let nfd = "Cha\u{0302}telet"; // 'C', 'h', 'a', combining circumflex, ...
+        let nfc = "Châtelet"; // precomposed â
+        assert_eq!(normalize_for_search(nfd), normalize_for_search(nfc));
+    }
+
+    #[test]
+    fn name_matches_query_fuzzy_uses_contains() {
+        // Fuzzy = substring match anywhere in the name.
+        assert!(name_matches_query("place de la nation", "nation", true));
+        assert!(name_matches_query("place de la nation", "place", true));
+        assert!(!name_matches_query("place de la nation", "lyon", true));
+    }
+
+    #[test]
+    fn name_matches_query_non_fuzzy_uses_prefix() {
+        // Non-fuzzy = prefix match only.
+        assert!(name_matches_query("place de la nation", "place", false));
+        assert!(!name_matches_query("place de la nation", "nation", false));
+    }
+
+    #[test]
+    fn name_matches_query_handles_empty_query() {
+        // An empty query degenerates to "matches everything" for both modes.
+        // The handler rejects sub-MIN_SEARCH_QUERY_LEN queries before calling
+        // this helper, so this is just documenting the pure-function behavior.
+        assert!(name_matches_query("anything", "", true));
+        assert!(name_matches_query("anything", "", false));
     }
 }

--- a/tests/handler_validation_tests.rs
+++ b/tests/handler_validation_tests.rs
@@ -124,7 +124,12 @@ async fn search_stations_rejects_short_query() {
     };
 
     let result = handler.search_stations_by_name(input).await;
-    assert!(result.is_err());
+    let err = result.unwrap_err();
+    // Short queries must surface as `validation_error`, not the catch-all
+    // `internal_error`: this matches the advertised JSON-Schema `minLength: 2`
+    // contract and routes the JSON-RPC error code to -32602 (Invalid params)
+    // rather than -32603 (Internal error).
+    assert_eq!(err.error_type(), "validation_error");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Focused maintenance pass across the three workstreams. Each workstream is a single commit on this branch.

## Workstream 1 — Architecture (`arch:`)

Found one clear precept divergence: `search_stations_by_name` returned `Error::Internal` (JSON-RPC `-32603`) when the `query` field was under the advertised `minLength: 2`. That contradicts both the published schema (it's a client contract violation) and the existing classification of the other input checks (radius/limit/coords all go to `Error::*` variants that map to `-32602 Invalid params`).

- Reclassify the rejection to `Error::Validation` (maps to `-32602`).
- Extract the name-matching logic out of the handler closure into two pure helpers (`normalize_for_search`, `name_matches_query`) so the rule can be exercised without a `VelibDataClient` stand-up. Closure body shrinks from ~10 lines to 2.

Bundled with the test commit since the helpers exist primarily to enable the new tests, matching the project's existing `arch+test:` convention (see `910dff9`).

## Workstream 2 — Testing (`test:`)

Picked `search_stations_by_name`'s string-matching logic as the highest-value undertested component. Disposition before this PR: the only coverage was a single `is_err()` assertion in `tests/handler_validation_tests.rs` confirming the short-query path failed *somehow* — accent normalization, case-folding, and the fuzzy-vs-prefix branch were untested. Key invariants:

1. Case-insensitive matching for ASCII and accented characters.
2. NFC / NFD equivalence after normalization (upstream Paris Open Data can deliver either).
3. `fuzzy = true` ⇒ substring; `fuzzy = false` ⇒ prefix.
4. Empty-query degenerates to "everything matches" (documents the handler-guarded contract).

Strategy: **unit tests** over the new pure helpers. Integration would have required either a fake `VelibDataClient` or live API access; doctests would have polluted the public API since the helpers are private; proptest would be overkill for four deterministic invariants. Unit tests sit in the same file as the function under test, keep test data minimal, and run in microseconds.

Also added one invariant test for `aggregate_area_statistics` covering the three load-bearing invariants (`total == mech + electric`, `operational ≤ total`, `occupancy_rate ≥ 0 ∧ finite`) across a mixed Open/Closed/Maintenance/no-real-time set. Strengthened the existing `search_stations_rejects_short_query` test to assert `error_type() == "validation_error"`, which is what the arch change actually enables.

Patch coverage on the new helpers should be 100%; project coverage gets a small bump from the new invariant test on `aggregate_area_statistics`.

## Workstream 3 — Clarity (`docs:`)

Two MCP spec documents had drifted significantly enough to actively mislead AI assistants and new contributors. Single commit:

`docs/api/mcp_interface_spec.md`
- `search_stations_by_name` limit max: `50` → `100` (matches `MAX_RESULT_LIMIT` and the schema advertised by `tools/list`).
- `plan_bike_journey` recommendation field names: `walk_to_pickup` / `walk_from_dropoff` → `straight_line_to_pickup_meters` / `straight_line_from_dropoff_meters` (matches `src/mcp/types.rs::JourneyRecommendation`).
- `confidence_score` minimum: `0` → `0.1` (the function clamps to `[0.1, 1.0]`).
- Replace the invented `Codes d'Erreur Standard` table (`-32001..-32005` with non-existent `error_type` values like `STATION_NOT_FOUND`) with the actual mapping derived from `src/error.rs`.
- Drop the fictional "Rate Limiting" and "Mode API Key" sections — the server has neither feature.
- Health resource example: remove the fabricated `hit_rate: 0.85` (the cache does not track hits/misses; this field was deliberately removed in a prior PR) and replace with the real `cache_stats` shape produced by `get_health_resource`.

`docs/api/mcp_schemas.md`
- Full rewrite. The previous version documented invented types that don't exist anywhere in the code: `StationStatus::Operational/Installed/OutOfService`, `ServiceCapabilities { renting_enabled, returning_enabled, installed }`, `BikeTypeFilter::MechanicalRequired/BothRequired`, `RealTimeStatus { station_code, valid_until, service }`, `ValidationError`, `PaginationInfo`, `DataSource`. Replaced with a short "source of truth" pointer to `src/types.rs` and `src/mcp/types.rs`, a serde-renaming table that matches the actual `#[serde(rename = ...)]` attributes, a corrected example, and a validation summary that reflects what `validate()` actually checks. Net: -253 lines.

## Verification

Run locally before pushing:

- `cargo build` (clean)
- `cargo test --lib` (90 passed, up from 84)
- `cargo test --tests` (all suites pass; ignored tests still ignored)
- `cargo fmt --check` (clean)
- `cargo clippy --all-targets --all-features -- -D warnings` (clean)

## Notes

- Skipped the broader "extract pagination loop in `VelibDataClient`" refactor — both `fetch_reference_stations` and `fetch_realtime_status` share structure, but consolidating would change function signatures and qualify as a speculative refactor by the task's rules.
- `.claude/etat_partage.json` is stale (claims Phase 2 with `last_updated: 2025-06-14` while `docs/context/etat_actuel.md` shows all phases complete) but is gated by harness permissions and was left alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQyYkAKbmXmojRkaxGZLJ7)_