### PR TITLE
feat(kani): foundation lints + contributor guide (refs #62, #63-#70)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ description = "MCP server for Velib Paris bike sharing data"
 keywords = ["mcp", "velib", "paris", "bike-sharing", "transport"]
 categories = ["api-bindings", "web-programming"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [dependencies]
 anyhow = "1.0"
 axum = { version = "0.7", features = ["ws"] }

--- a/docs/kani.md
+++ b/docs/kani.md
@@ -1,0 +1,69 @@
+# Kani Formal Verification
+
+Kani is a bit-precise model checker for Rust. It complements unit tests and proptest
+by exhaustively proving safety properties over bounded input domains — surfacing
+overflow, panic, and assertion violations as concrete counterexamples.
+
+## When to add a Kani harness
+
+Reach for a Kani harness when reviewing code that has:
+
+- Arithmetic that can overflow (`+`, `-`, `*`, `pow`, `as` casts widening or narrowing)
+- `unwrap()` / `expect()` on a value whose `Some`/`Ok` invariant is non-trivial
+- Float → integer casts (NaN / infinity are UB-adjacent)
+- String length checks (`len()` is byte count, not char count)
+- Cross-field validation invariants (e.g. `bikes + docks <= capacity`)
+
+Unit tests prove specific examples. Kani proves the property holds for *all* inputs in
+the domain you bound.
+
+## Running locally
+
+```
+cargo install --locked kani-verifier
+cargo kani setup
+cargo kani                       # all harnesses
+cargo kani --harness <name>      # single harness
+```
+
+## CI integration
+
+`.github/workflows/kani.yml` should run `model-checking/kani-github-action@v1.1` on
+every PR. The action installs Kani, runs all `#[kani::proof]` harnesses, and fails
+the build on any counterexample. (Workflow file pending manual addition — see the
+foundation PR body for the YAML.)
+
+## Harness placement convention
+
+Inline in the source file, behind `#[cfg(kani)]`:
+
+```rust
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn proof_foo_does_not_panic() {
+        let x: u32 = kani::any();
+        kani::assume(x <= 1000);
+        let _ = foo(x);
+    }
+}
+```
+
+Name harnesses `proof_<property>` for clarity in CI logs.
+
+## Per-component plan (issue #62)
+
+| Issue | File | Harnesses |
+|---|---|---|
+| #63 | `src/data/retry.rs` | `2_u64.pow(attempt)` overflow threshold; `last_error.unwrap()` loop invariant; total backoff bound |
+| #64 | `src/types.rs` | Haversine non-negative & finite & ≤ Earth circumference; metro ⊂ service-area; `distance_to` symmetric; invalid coords rejected |
+| #65 | `src/mcp/handlers.rs` | `as u32` cast input finite & non-negative & ≤ `u32::MAX` |
+| #66 | `src/mcp/handlers.rs` | `max_walk_distance == 0` reaches division (counterexample); confidence_score in [0,1]; no intermediate NaN/inf |
+| #67 | `src/data/client.rs` | `u64 as u16` silent truncation counterexample; `try_from` is lossless for ≤ 65535 |
+| #68 | `src/types.rs` | `total_bikes + available_docks ≤ capacity`; `saturating_add` documented; `StationReference::validate` covers all invariants |
+| #69 | `src/data/cache.rs` | expired iff `now > expires_at`; `cleanup_expired` exact; insert→get roundtrip; TTL arithmetic bound |
+| #70 | `src/mcp/handlers.rs` | `len() < 2` byte/char mismatch counterexample; radius ≤ `MAX_SEARCH_RADIUS`; limit ≤ `MAX_RESULT_LIMIT` |
+
+Each row lands as its own draft PR per #62's instructions.


### PR DESCRIPTION
job-id: HGdco
oldest-issue-id: 9

## Summary

Sets up the kani formal-verification foundation in this repo so that per-component proof PRs for #63–#70 land cleanly. Does **not** implement any harnesses itself — those come in 8 follow-up PRs per #62's plan.

Two pieces:

1. `Cargo.toml` — adds `[lints.rust] unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }` so that `#[cfg(kani)]` modules don't trigger `-D warnings` in CI when kani isn't active.
2. `docs/kani.md` — contributor guide: when to write a Kani harness, how to run locally, placement convention, plus a per-issue harness plan for #63–#70 (copied from the parent #62 issue body).

## What's incomplete and why

- **`.github/workflows/kani.yml` is NOT in this PR.** The MCP GitHub App token used by this cron job lacks the `workflows` permission, so the push to `.github/workflows/` returned `403 Resource not accessible by integration`. This is the same blocker that stopped theatron's PR #43 from pushing its workflow file.

  The workflow content that needs to be added manually (or by a token with `workflows` permission):

  ```yaml
  name: kani

  on:
    push:
      branches: [main]
    pull_request:

  jobs:
    kani:
      name: Kani Proofs
      runs-on: ubuntu-latest
      timeout-minutes: 30
      steps:
        - uses: actions/checkout@v4
        - uses: model-checking/kani-github-action@v1.1
  ```

- **No harnesses yet.** #63–#70 each need their own follow-up PR with the inline `#[cfg(kani)] mod kani_proofs { ... }` block. See `docs/kani.md` for the planned harnesses per file.

## Fingerprint / idempotency

This PR is tagged `job-id: HGdco` (matches branch suffix) and `oldest-issue-id: 9` (velib-mcp #9, the oldest issue in this cron's LIFO window). Future cron runs should detect this open foundation PR and NO-OP on the kani-setup work rather than re-creating it.

## Cron policy

- Stays as **draft**. Do not add `ready-for-review` — that promotion is the janitor's call per the LIFO cron design.
- `Refs` (not `Closes`) #62, #63, #64, #65, #66, #67, #68, #69, #70 — the foundation enables those issues but does not close them.

---

🤖 Generated by [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174cnPBFxKYVkfaXakX3M1B)_